### PR TITLE
Update run-scrape.yaml to resolve missing tag_name issue

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -49,6 +49,7 @@ jobs:
       uses: softprops/action-gh-release@v2
 
       with:
+        tag_name: ${{ steps.date.outputs.date }}
         name: release-${{ steps.date.outputs.date }}
         body_path: release_note.txt
         files: |


### PR DESCRIPTION
This PR adds 'tag_name' to the "Release" step so that it creates a tag, which is apparently a requirement for the action to make a release.

*(I made this change a while ago when I was experimenting with running the scraper via the workflow, but I hadn't submitted it because I hadn't gotten into automating the ECCO pipeline yet. Now that we're rapidly approaching that point, I think it's a good time to contribute back upstream. 🙂  I'll be more prompt about it in the future, too.)*