### PR TITLE
feat(scraper): iterate over areatype in master_table

### DIFF
--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -26,6 +26,8 @@ options are not valid for some of the other options.
 
 """
 
+from collections.abc import Iterable
+
 import httpx
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -170,50 +172,76 @@ def get_table(
 # This function uses argparse to collect the command line arguments
 # and then calls get_table() with those arguments.
 # use last five years of data (year=0), all states (stateFIPS=00)
-def master_table(year: str = "0", stateFIPS="00", _type="incd"):
+def master_table(
+    year: str = "0",
+    stateFIPS: str = "00",
+    _type: str = "incd",
+    areatypes: Iterable[str] = ("county",),
+):
+    """Scrape every (cancer × age × sex × race × stage × areatype) combination.
+
+    Parameters
+    ----------
+    areatypes : iterable of str
+        One or more areatype values to iterate. The website supports
+        ``"county"``, ``"state"``, and ``"hsa"`` (health service area).
+        Defaults to ``("county",)`` for backward compatibility with the
+        single-areatype behaviour of earlier releases. Pass
+        ``("county", "state")`` (the new default in ``main``) to capture
+        state-level rollups — including the national row at FIPS ``00000`` —
+        in the same output frame.
+    """
     select_options = get_select_options()
     logger.info(str(select_options))
     dflist = []
     cancers = list(select_options["cancer"].keys())
     logger.info(f"Number of cancers: {len(cancers)}")
-    for cancer in list(select_options["cancer"].keys()):
-        cancer_name = select_options["cancer"][cancer]
-        logger.info(f"Getting data for cancer: {cancer_name}")
+    for areatype in areatypes:
+        logger.info(f"Getting data for areatype: {areatype}")
+        for cancer in cancers:
+            cancer_name = select_options["cancer"][cancer]
+            logger.info(
+                f"Getting data for cancer: {cancer_name} (areatype={areatype})"
+            )
 
-        # The state cancer profiles folks in their
-        # decided to make the age
-        # groups for cancer 515 and 516 (pediatrics) different
-        # than the other cancers. So we have to
-        # handle them separately.
-        if cancer == "516":
-            ages = ["016"]
-        elif cancer == "515":
-            ages = ["015"]
-        else:
-            ages = select_options["age"].keys()
-        for age in ages:
-            for sex in select_options["sex"].keys():
-                for race in select_options["race"].keys():
-                    for stage in select_options["stage"].keys():
-                        try:
-                            df = get_table(
-                                cancer=cancer,
-                                age=age,
-                                sex=sex,
-                                race=race,
-                                stage=stage,
-                                _type=_type,
-                            )
-                            logger.debug(
-                                f"Got data for {cancer_name}, shape {df.shape}"
-                            )
-                            dflist.append(df)
-                        except KeyboardInterrupt:
-                            raise
-                        except Exception as e:
-                            logger.debug("Caught an exception, but ignoring it")
-                            logger.debug(e)
-                            pass
+            # The state cancer profiles folks in their
+            # decided to make the age
+            # groups for cancer 515 and 516 (pediatrics) different
+            # than the other cancers. So we have to
+            # handle them separately.
+            if cancer == "516":
+                ages = ["016"]
+            elif cancer == "515":
+                ages = ["015"]
+            else:
+                ages = select_options["age"].keys()
+            for age in ages:
+                for sex in select_options["sex"].keys():
+                    for race in select_options["race"].keys():
+                        for stage in select_options["stage"].keys():
+                            try:
+                                df = get_table(
+                                    cancer=cancer,
+                                    age=age,
+                                    sex=sex,
+                                    race=race,
+                                    stage=stage,
+                                    areatype=areatype,
+                                    _type=_type,
+                                )
+                                logger.debug(
+                                    f"Got data for {cancer_name} "
+                                    f"(areatype={areatype}), shape {df.shape}"
+                                )
+                                dflist.append(df)
+                            except KeyboardInterrupt:
+                                raise
+                            except Exception as e:
+                                logger.debug(
+                                    "Caught an exception, but ignoring it"
+                                )
+                                logger.debug(e)
+                                pass
     df = pd.concat(dflist)
     df[["locale", "state"]] = df.county.str.replace(
         r"\(.*\)", "", regex=True
@@ -256,12 +284,18 @@ def main():
     logger.info("Getting select options")
     json.dump(get_select_options(), open("select_options.json", "w"))
 
-    logger.info("Getting incidence data")
-    df = master_table(_type="incd")
+    # Iterate county + state so downstream consumers get state rollups and
+    # the national row (FIPS 00000) in the same file. HSA is intentionally
+    # omitted from the default release run — it uses a non-FIPS area key
+    # and most downstream joins assume county/state FIPS.
+    default_areatypes = ("county", "state")
+
+    logger.info("Getting incidence data (areatypes=%s)", default_areatypes)
+    df = master_table(_type="incd", areatypes=default_areatypes)
     logger.info("Saving incidence data with shape: %s", str(df.shape))
     df.to_csv("state_cancer_profiles_incidence.csv.gz", index=False, compression="gzip")
-    logger.info("Getting death data")
-    df = master_table(_type="death")
+    logger.info("Getting death data (areatypes=%s)", default_areatypes)
+    df = master_table(_type="death", areatypes=default_areatypes)
     logger.info("Saving mortality data with shape: %s", str(df.shape))
     df.to_csv("state_cancer_profiles_mortality.csv.gz", index=False, compression="gzip")
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -192,6 +192,73 @@ def test_get_table_uses_correct_url():
     assert "output=1" in url
 
 
+def test_master_table_iterates_areatypes():
+    """master_table passes each requested areatype through to get_table."""
+    captured_areatypes = []
+
+    def fake_get_table(**kwargs):
+        captured_areatypes.append(kwargs.get("areatype"))
+        import pandas as pd
+        # master_table splits `county` on ", " into (locale, state) — use a
+        # comma-bearing string so the split produces two columns.
+        return pd.DataFrame(
+            {
+                "county": ["Somewhere County, CO"],
+                "fips": ["08001"],
+                "age_adjusted_incidence_raterate_note___cases_per_100_000": [1.0],
+            }
+        )
+
+    # Trim the select option universe so the run is fast.
+    tiny_opts = {
+        "cancer": {"001": "All Cancer Sites"},
+        "age": {"001": "All Ages"},
+        "sex": {"0": "Both Sexes"},
+        "race": {"00": "All Races (includes Hispanic)"},
+        "stage": {"999": "All Stages"},
+        "year": {"0": "Latest 5-year average"},
+        "areatype": {"county": "By County", "state": "By State"},
+    }
+
+    with patch.object(scraper, "get_select_options", return_value=tiny_opts), \
+         patch.object(scraper, "get_table", side_effect=fake_get_table):
+        scraper.master_table(areatypes=("county", "state"))
+
+    assert captured_areatypes == ["county", "state"]
+
+
+def test_master_table_default_areatype_is_county_only():
+    """Backward-compat: default areatypes preserves county-only behaviour."""
+    captured_areatypes = []
+
+    def fake_get_table(**kwargs):
+        captured_areatypes.append(kwargs.get("areatype"))
+        import pandas as pd
+        return pd.DataFrame(
+            {
+                "county": ["Somewhere County, CO"],
+                "fips": ["08001"],
+                "age_adjusted_incidence_raterate_note___cases_per_100_000": [1.0],
+            }
+        )
+
+    tiny_opts = {
+        "cancer": {"001": "All Cancer Sites"},
+        "age": {"001": "All Ages"},
+        "sex": {"0": "Both Sexes"},
+        "race": {"00": "All Races (includes Hispanic)"},
+        "stage": {"999": "All Stages"},
+        "year": {"0": "Latest 5-year average"},
+        "areatype": {"county": "By County"},
+    }
+
+    with patch.object(scraper, "get_select_options", return_value=tiny_opts), \
+         patch.object(scraper, "get_table", side_effect=fake_get_table):
+        scraper.master_table()
+
+    assert set(captured_areatypes) == {"county"}
+
+
 def test_get_table_death_url():
     """get_table with _type='death' should use the deathrates endpoint."""
     captured_urls = []


### PR DESCRIPTION
## Summary
- `master_table` now accepts an `areatypes` iterable (default `("county",)` for backward compatibility) and dispatches one inner loop per areatype.
- CLI `main` updated to scrape `("county", "state")` so the released CSVs include state-level rollups and the national row at FIPS `00000` in a single file.
- HSA areatype (`"hsa"`) is supported but intentionally omitted from the default release run because its area keys aren't FIPS and most downstream joins assume county/state FIPS. Opt in via `master_table(areatypes=("county", "state", "hsa"))`.

## Motivation
Downstream consumers (e.g. the Colorado Cancer Atlas chat tool) want a single national/state benchmark in the same dataset as the county rows, instead of inferring it from peer-county aggregation. Adding state-level rollups also gives every state a per-cancer "you are here" anchor for free.

## Behavior changes
- `state_cancer_profiles_incidence.csv.gz` and `state_cancer_profiles_mortality.csv.gz` will grow by ~50 state rows + 1 national row per (cancer × age × sex × race × stage) combo — single-digit % growth.
- The existing `locale_type` logic already handles state/national correctly (fips ending in `000` → state; fips starting with `00` → national), so no parsing changes are needed.
- `master_table()` default behaviour is unchanged.

## Test plan
- [x] `pytest tests/` — 19 passing (added 2 tests for areatype iteration + default backward-compat).
- [ ] End-to-end run via `python -m scps.scraper` once merged — verify CO/US rows appear in the resulting CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)