### PR TITLE
feat: add risk-factor and demographics scrapers + click CLI

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -28,7 +28,7 @@ jobs:
       run: uv sync --frozen
 
     - name: Run scrape
-      run: uv run python -m scps.scraper
+      run: uv run scps-scraper scrape
 
     - name: Tag with gh_hash
       run: echo ${{ github.sha }} > gh_hash.txt
@@ -54,4 +54,6 @@ jobs:
           gh_hash.txt
           state_cancer_profiles_incidence.csv.gz
           state_cancer_profiles_mortality.csv.gz
+          state_cancer_profiles_risk.csv.gz
+          state_cancer_profiles_demographics.csv.gz
           select_options.json

--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@
 [![DOI](https://zenodo.org/badge/794255451.svg)](https://doi.org/10.5281/zenodo.13174526)
 
 
-The [state cancer profiles website](https://statecancerprofiles.cancer.gov/) hosts visualization and data exploration tools for cancer incidence and mortality in the United States. For casual browsing, the website is great. However, if having access to the underlying data is the goal, the existing site does not have bulk downloads or an API. Therefore, **we provide bulk data scraped from the website for data science applications**. 
+The [state cancer profiles website](https://statecancerprofiles.cancer.gov/) hosts visualization and data exploration tools for cancer incidence and mortality in the United States. For casual browsing, the website is great. However, if having access to the underlying data is the goal, the existing site does not have bulk downloads or an API. Therefore, **we provide bulk data scraped from the website for data science applications**.
 
-For the TLDR, the data for _incidence_ and _mortality_ are available for download from:
+Each release ships four gzipped CSVs:
+
+- `state_cancer_profiles_incidence.csv.gz` — age-adjusted incidence rates (by cancer, age, sex, race, stage)
+- `state_cancer_profiles_mortality.csv.gz` — age-adjusted mortality rates (same dimensions)
+- `state_cancer_profiles_risk.csv.gz` — BRFSS-derived screening and risk-factor prevalence (alcohol, smoking, mammograms, colonoscopy, HPV vaccination, etc.)
+- `state_cancer_profiles_demographics.csv.gz` — ACS-derived demographics (crowding, education, poverty, SVI, etc.)
+
+All four files cover both county-level and state-level rows in the same file (plus the national row at FIPS `00000`), distinguished by the `locale_type` column.
+
+Download from:
 
 - <https://github.com/seandavi/state-cancer-profile-scraper/releases/latest>
 
-A new release is **generated every month with the latest data**. 
+A new release is **generated every month with the latest data**.
 
 ## Contents
 
@@ -120,13 +129,29 @@ pip install git+https://github.com/seandavi/state-cancer-profiles-scraper.git
 
 ### Running the scraper
 
-To run the scraper, use the following command:
+After installation, a `scps-scraper` command is available:
+
+```bash
+# Scrape everything (incidence, mortality, risk, demographics)
+scps-scraper scrape
+
+# Pick a subset
+scps-scraper scrape --datasets risk --datasets demographics
+
+# Write to a specific directory
+scps-scraper scrape --output-dir ./data
+
+# See all options
+scps-scraper scrape --help
+```
+
+The legacy module invocation is preserved and produces the same outputs:
 
 ```bash
 python -m scps.scraper
 ```
 
-The scraper will save the data in current working directory.
+The scraper writes gzipped CSVs to the current working directory (or `--output-dir`).
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "bs4>=0.0.2",
+    "click>=8.1",
     "httpx>=0.27.0,<0.28.0",
     "pandas>=2.2.2,<3.0.0",
 ]
@@ -17,6 +18,9 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
 ]
+
+[project.scripts]
+scps-scraper = "scps.cli:cli"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scps/cli.py
+++ b/scps/cli.py
@@ -1,0 +1,133 @@
+"""Click-based command-line interface for the state cancer profiles scraper.
+
+Installed as the ``scps-scraper`` console script via ``pyproject.toml``::
+
+    scps-scraper scrape                 # all datasets
+    scps-scraper scrape --datasets risk # one dataset
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import click
+
+from scps import demographics, risk, scraper
+
+logger = logging.getLogger("scps.cli")
+
+DATASET_CHOICES = ("incidence", "mortality", "risk", "demographics")
+
+OUTPUT_FILES = {
+    "incidence": "state_cancer_profiles_incidence.csv.gz",
+    "mortality": "state_cancer_profiles_mortality.csv.gz",
+    "risk": "state_cancer_profiles_risk.csv.gz",
+    "demographics": "state_cancer_profiles_demographics.csv.gz",
+}
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),
+    default="INFO",
+    show_default=True,
+)
+def cli(log_level: str) -> None:
+    """Scrape data from the State Cancer Profiles website."""
+    logging.basicConfig(level=getattr(logging, log_level.upper()))
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+@cli.command()
+@click.option(
+    "--datasets",
+    "-d",
+    multiple=True,
+    type=click.Choice(DATASET_CHOICES, case_sensitive=False),
+    help=(
+        "Dataset(s) to scrape. Repeat the flag for multiple datasets. "
+        "Defaults to all four."
+    ),
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    default=Path("."),
+    show_default=True,
+    help="Directory to write the gzipped CSVs into.",
+)
+@click.option(
+    "--areatypes",
+    multiple=True,
+    type=click.Choice(["county", "state", "hsa"], case_sensitive=False),
+    help=(
+        "Areatypes to iterate for incidence/mortality/demographics. "
+        "Defaults to ('county', 'state')."
+    ),
+)
+def scrape(
+    datasets: tuple[str, ...],
+    output_dir: Path,
+    areatypes: tuple[str, ...],
+) -> None:
+    """Run the scraper and write gzipped CSVs to ``--output-dir``."""
+    selected = tuple(d.lower() for d in datasets) or DATASET_CHOICES
+    output_dir.mkdir(parents=True, exist_ok=True)
+    areas = tuple(a.lower() for a in areatypes) or ("county", "state")
+
+    if "incidence" in selected or "mortality" in selected:
+        # Re-export the live select options alongside the data so anyone
+        # consuming the release can decode metadata IDs without re-scraping.
+        logger.info("Fetching incidence/mortality select options")
+        options_path = output_dir / "select_options.json"
+        with options_path.open("w") as fh:
+            json.dump(scraper.get_select_options(), fh)
+
+    if "incidence" in selected:
+        _run_incidence_or_mortality("incd", areas, output_dir)
+    if "mortality" in selected:
+        _run_incidence_or_mortality("death", areas, output_dir)
+    if "risk" in selected:
+        _run_risk(output_dir)
+    if "demographics" in selected:
+        _run_demographics(areas, output_dir)
+
+
+def _run_incidence_or_mortality(
+    type_code: str, areatypes: tuple[str, ...], output_dir: Path
+) -> None:
+    label = "incidence" if type_code == "incd" else "mortality"
+    logger.info("Scraping %s (areatypes=%s)", label, areatypes)
+    df = scraper.master_table(_type=type_code, areatypes=areatypes)
+    out = output_dir / OUTPUT_FILES[label]
+    logger.info("Writing %s (shape=%s)", out, df.shape)
+    df.to_csv(out, index=False, compression="gzip")
+
+
+def _run_risk(output_dir: Path) -> None:
+    logger.info("Scraping risk factors")
+    df = risk.risk_master_table()
+    out = output_dir / OUTPUT_FILES["risk"]
+    logger.info("Writing %s (shape=%s)", out, df.shape)
+    df.to_csv(out, index=False, compression="gzip")
+
+
+def _run_demographics(areatypes: tuple[str, ...], output_dir: Path) -> None:
+    # The demographics endpoint doesn't accept all the same areatypes as
+    # incidence/mortality; filter to those it supports.
+    demo_areatypes = tuple(a for a in areatypes if a in ("county", "state", "hsa"))
+    if not demo_areatypes:
+        demo_areatypes = ("county", "state")
+    logger.info("Scraping demographics (areatypes=%s)", demo_areatypes)
+    df = demographics.demographics_master_table(areatypes=demo_areatypes)
+    out = output_dir / OUTPUT_FILES["demographics"]
+    logger.info("Writing %s (shape=%s)", out, df.shape)
+    df.to_csv(out, index=False, compression="gzip")
+
+
+if __name__ == "__main__":
+    cli()

--- a/scps/demographics.py
+++ b/scps/demographics.py
@@ -1,0 +1,283 @@
+"""Scraper for the State Cancer Profiles demographics endpoint.
+
+Data source: ``https://statecancerprofiles.cancer.gov/demographics/index.php``
+
+The endpoint serves ACS-derived demographic indicators (crowding, education,
+poverty, SVI, etc.). As with the risk endpoint, the demographic-variable
+dropdown is populated by JavaScript from ``/demographics/censusJSDefines.js``
+keyed by topic, so we parse that file alongside the HTML select options.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import httpx
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from scps.scraper import column_text_replace
+
+logger = logging.getLogger("scps.demographics")
+
+DEMO_BASE_URL = "https://statecancerprofiles.cancer.gov/demographics/index.php"
+DEMO_DEFINES_URL = (
+    "https://statecancerprofiles.cancer.gov/demographics/censusJSDefines.js"
+)
+
+_PLACEHOLDER_VALUES = {"*", "**", "***", "****", "*****"}
+
+# Matches lines like:  ed_array['00004']="Less than 9th grade";
+#                       population_ages_array['00002'] = "Ages under 18";
+# Backreferenced quotes (\2 and \4) so apostrophes inside double-quoted
+# labels (e.g. "bachelor's degree") aren't treated as terminators.
+_DEMO_LINE_RE = re.compile(
+    r"""^\s*(?P<array>[a-z_]+_array)\[(['"])(?P<id>[^'"]+)\2\]\s*=\s*"""
+    r"""(['"])(?P<label>.*?)\4\s*;""",
+    re.MULTILINE,
+)
+
+
+# Matches /* ... */ block comments (non-greedy, multi-line).
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+# Arrays in the JS file that look like topic definitions but aren't —
+# they're the picker-label lookups, not demo-id mappings.
+_NON_TOPIC_ARRAYS = {"topic_box"}
+
+
+def parse_census_defines(js_text: str) -> dict[str, dict[str, str]]:
+    """Parse ``censusJSDefines.js`` into ``{topic: {demo_id: label}}``.
+
+    The ``pop`` topic is a special case: its ids live in two sibling arrays
+    (``population_ages_array``, ``population_races_array``) that are
+    re-exported by ``pop_array['Ages']`` / ``pop_array['Races']`` at runtime.
+    We merge both into the ``pop`` mapping here.
+    """
+    # Strip block comments first so commented-out array definitions
+    # (e.g. ur_array) don't get parsed as live topics.
+    js_text = _BLOCK_COMMENT_RE.sub("", js_text)
+
+    flat: dict[str, dict[str, str]] = {}
+    for raw_line in js_text.splitlines():
+        if raw_line.lstrip().startswith("//"):
+            continue
+        match = _DEMO_LINE_RE.match(raw_line)
+        if not match:
+            continue
+        array = match.group("array")
+        demo_id = match.group("id")
+        if demo_id in _PLACEHOLDER_VALUES:
+            continue
+        flat.setdefault(array, {})[demo_id] = match.group("label")
+
+    result: dict[str, dict[str, str]] = {}
+    for array_name, mapping in flat.items():
+        if not array_name.endswith("_array"):
+            continue
+        topic = array_name[: -len("_array")]
+        if topic.startswith("population_") or topic in _NON_TOPIC_ARRAYS:
+            # Folded into pop_array below, or not a real topic.
+            continue
+        result[topic] = dict(mapping)
+
+    pop_merged: dict[str, str] = {}
+    pop_merged.update(flat.get("population_ages_array", {}))
+    pop_merged.update(flat.get("population_races_array", {}))
+    if pop_merged:
+        result["pop"] = pop_merged
+
+    return result
+
+
+def _parse_select_options(html: str) -> dict[str, dict[str, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    result: dict[str, dict[str, str]] = {}
+    for select in soup.find_all("select"):
+        sid = select.attrs.get("id")
+        if not sid:
+            continue
+        opts: dict[str, str] = {}
+        for option in select.find_all("option"):
+            value = option.attrs.get("value")
+            if value is None or value in _PLACEHOLDER_VALUES:
+                continue
+            text = option.get_text().strip()
+            if text.startswith("---"):
+                continue
+            opts[value] = text
+        result[sid] = opts
+    return result
+
+
+def get_demographics_options() -> dict[str, Any]:
+    """Discover demographics select options from the live website."""
+    html = httpx.get(DEMO_BASE_URL).text
+    select_opts = _parse_select_options(html)
+
+    js_text = httpx.get(DEMO_DEFINES_URL).text
+    demo_by_topic = parse_census_defines(js_text)
+
+    return {
+        "topic": select_opts.get("topic", {}),
+        "demo_by_topic": demo_by_topic,
+        "areatype": select_opts.get("areatype", {}),
+        "race": select_opts.get("race", {}),
+        "sex": select_opts.get("sex", {}),
+        "age": select_opts.get("age", {}),
+        "statefips": select_opts.get("statefips", {}),
+    }
+
+
+def _label(options: dict[str, str], key: str) -> str:
+    return options.get(key, key)
+
+
+def get_demographics_table(
+    topic: str,
+    demo: str,
+    areatype: str = "county",
+    statefips: str = "00",
+    race: str = "00",
+    sex: str = "0",
+    age: str = "001",
+    options: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Fetch a single demographics CSV and return it as a normalized DataFrame.
+
+    Column shape varies by ``areatype``: state/county use ``State``/``County``
+    + ``FIPS``, HSA uses ``Health Service Area`` + ``HSA_Code``. We rename
+    both to ``reported_locale`` + ``area_code`` so downstream code doesn't
+    have to branch.
+    """
+    url = (
+        f"{DEMO_BASE_URL}?statefips={statefips}&areatype={areatype}"
+        f"&topic={topic}&demo={demo}&race={race}&sex={sex}&age={age}"
+        f"&type=manyareacensus&sortVariableName=value&sortOrder=default&output=1"
+    )
+    logger.debug(url)
+
+    df = pd.read_csv(
+        url,
+        skiprows=6,
+        low_memory=False,
+        na_values=["*", "N/A", " N/A", "N/A ", " N/A "],
+        skipinitialspace=True,
+        dtype={"FIPS": str, "HSA_Code": str},
+    )
+    df.columns = [column_text_replace(c) for c in df.columns]
+
+    # Normalize locale column (varies by areatype).
+    locale_renames = {
+        "state": "reported_locale",
+        "county": "reported_locale",
+        "health_service_area": "reported_locale",
+        "hsa_code": "area_code",
+        "fips": "area_code",
+    }
+    df = df.rename(columns={k: v for k, v in locale_renames.items() if k in df.columns})
+
+    # Rename percent column. The raw-count column name varies with the demo
+    # (e.g. "Households (with >1 Person Per Room)" vs "People (Male)") so we
+    # don't try to rename it — callers can look it up via demo_label.
+    if "value_percent" in df.columns:
+        df = df.rename(columns={"value_percent": "percent"})
+    if "rank_within_us" in df.columns:
+        df = df.rename(columns={"rank_within_us": "rank"})
+
+    opts = options or {}
+    df["topic"] = topic
+    df["topic_label"] = _label(opts.get("topic", {}), topic)
+    df["demo"] = demo
+    df["demo_label"] = _label(opts.get("demo_by_topic", {}).get(topic, {}), demo)
+    df["areatype"] = _label(opts.get("areatype", {}), areatype)
+    df["race"] = _label(opts.get("race", {}), race)
+    df["sex"] = _label(opts.get("sex", {}), sex)
+    df["age"] = _label(opts.get("age", {}), age)
+
+    df.loc[df["area_code"].isna(), "area_code"] = ""
+    df["state_fips"] = df["area_code"].str[:2]
+    df["locale_type"] = "other"
+    df.loc[df["area_code"].str.startswith("00"), "locale_type"] = "national"
+    if areatype == "state":
+        df.loc[df["area_code"].str.endswith("000") & ~df["area_code"].str.startswith("00"), "locale_type"] = "state"
+    elif areatype == "county":
+        df.loc[
+            df["area_code"].str.len().eq(5) & ~df["area_code"].str.endswith("000"),
+            "locale_type",
+        ] = "county"
+    elif areatype == "hsa":
+        df.loc[~df["area_code"].str.startswith("00"), "locale_type"] = "hsa"
+
+    df["_extracted_at"] = pd.Timestamp.now().isoformat()
+    df["url"] = url.replace("&output=1", "")
+
+    if "percent" in df.columns:
+        df["percent"] = pd.to_numeric(df["percent"], errors="coerce")
+
+    return df
+
+
+def demographics_master_table(
+    areatypes: Iterable[str] = ("county", "state"),
+    options: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Iterate over every ``(topic, demo, areatype, race, sex, age)`` combo.
+
+    Parameters
+    ----------
+    areatypes : iterable of str
+        Defaults to ``("county", "state")``. The website also supports
+        ``"hsa"`` (health service area) but it's omitted by default since
+        HSA codes don't slot into FIPS-keyed downstream joins.
+    """
+    opts = options or get_demographics_options()
+    dflist: list[pd.DataFrame] = []
+
+    topics = opts["topic"]
+    demo_by_topic = opts["demo_by_topic"]
+    races = opts["race"]
+    sexes = opts["sex"]
+    ages = opts["age"]
+
+    logger.info(
+        "Demographics scrape: %d topics, areatypes=%s",
+        len(topics), list(areatypes),
+    )
+
+    for areatype in areatypes:
+        for topic_id in topics:
+            demos = demo_by_topic.get(topic_id, {})
+            if not demos:
+                logger.debug("No demos defined for topic %s; skipping", topic_id)
+                continue
+            for demo_id in demos:
+                for race_id in races:
+                    for sex_id in sexes:
+                        for age_id in ages:
+                            try:
+                                df = get_demographics_table(
+                                    topic=topic_id,
+                                    demo=demo_id,
+                                    areatype=areatype,
+                                    race=race_id,
+                                    sex=sex_id,
+                                    age=age_id,
+                                    options=opts,
+                                )
+                                dflist.append(df)
+                            except KeyboardInterrupt:
+                                raise
+                            except Exception as exc:
+                                logger.debug(
+                                    "Skipped %s/%s area=%s race=%s sex=%s age=%s: %s",
+                                    topic_id, demo_id, areatype,
+                                    race_id, sex_id, age_id, exc,
+                                )
+
+    if not dflist:
+        return pd.DataFrame()
+    return pd.concat(dflist, ignore_index=True)

--- a/scps/risk.py
+++ b/scps/risk.py
@@ -1,0 +1,252 @@
+"""Scraper for the State Cancer Profiles screening & risk-factor endpoint.
+
+Data source: ``https://statecancerprofiles.cancer.gov/risk/index.php``
+
+The risk endpoint exposes BRFSS-derived prevalence of screening behaviors
+(mammograms, colonoscopy, HPV vaccination) and risk factors (binge drinking,
+smoking, obesity). The dropdown that picks the actual risk factor is
+populated by JavaScript from ``/risk/riskJSDefines.js``, keyed by topic, so
+we parse that file alongside the HTML select options.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import httpx
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from scps.scraper import column_text_replace
+
+logger = logging.getLogger("scps.risk")
+
+RISK_BASE_URL = "https://statecancerprofiles.cancer.gov/risk/index.php"
+RISK_DEFINES_URL = "https://statecancerprofiles.cancer.gov/risk/riskJSDefines.js"
+
+# These placeholder values appear in the HTML selects as "--- choose X ---"
+# prompts and should never be used as real query parameters.
+_PLACEHOLDER_VALUES = {"*", "**", "***", "****", "*****"}
+
+# Matches lines like:  alcohol_array['v505']="Binge drinking ...";
+# Captures the topic, risk id, and label. Backreferences (\2 and \4) ensure
+# the closing quote matches the opening one, so apostrophes inside a
+# double-quoted label (e.g. "Men's Health") aren't treated as terminators.
+_RISK_LINE_RE = re.compile(
+    r"""^\s*(?P<topic>[a-z]+)_array\[(['"])(?P<risk>[^'"]+)\2\]\s*=\s*"""
+    r"""(['"])(?P<label>.*?)\4\s*;""",
+    re.MULTILINE,
+)
+
+
+# Matches /* ... */ block comments (non-greedy, multi-line).
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def parse_risk_defines(js_text: str) -> dict[str, dict[str, str]]:
+    """Parse ``riskJSDefines.js`` into ``{topic: {risk_id: label}}``.
+
+    Both ``//`` line comments and ``/* ... */`` block comments are skipped,
+    and the placeholder ``'**'`` "choose risk factor" entry is excluded.
+    """
+    js_text = _BLOCK_COMMENT_RE.sub("", js_text)
+    result: dict[str, dict[str, str]] = {}
+    for raw_line in js_text.splitlines():
+        if raw_line.lstrip().startswith("//"):
+            continue
+        match = _RISK_LINE_RE.match(raw_line)
+        if not match:
+            continue
+        topic = match.group("topic")
+        risk = match.group("risk")
+        if risk in _PLACEHOLDER_VALUES:
+            continue
+        result.setdefault(topic, {})[risk] = match.group("label")
+    return result
+
+
+def _parse_select_options(html: str) -> dict[str, dict[str, str]]:
+    soup = BeautifulSoup(html, "html.parser")
+    result: dict[str, dict[str, str]] = {}
+    for select in soup.find_all("select"):
+        sid = select.attrs.get("id")
+        if not sid:
+            continue
+        opts: dict[str, str] = {}
+        for option in select.find_all("option"):
+            value = option.attrs.get("value")
+            if value is None or value in _PLACEHOLDER_VALUES:
+                continue
+            text = option.get_text().strip()
+            if text.startswith("---"):
+                continue
+            opts[value] = text
+        result[sid] = opts
+    return result
+
+
+def get_risk_options() -> dict[str, Any]:
+    """Discover risk select options from the live website.
+
+    Returns a dict with keys ``topic``, ``risk_by_topic``, ``race``, ``sex``,
+    ``statefips``, and ``datatype``. The ``risk_by_topic`` value is a nested
+    ``{topic: {risk_id: label}}`` mapping parsed from ``riskJSDefines.js``.
+    """
+    html = httpx.get(RISK_BASE_URL).text
+    select_opts = _parse_select_options(html)
+
+    js_text = httpx.get(RISK_DEFINES_URL).text
+    risk_by_topic = parse_risk_defines(js_text)
+
+    return {
+        "topic": select_opts.get("topic", {}),
+        "risk_by_topic": risk_by_topic,
+        "race": select_opts.get("race", {}),
+        "sex": select_opts.get("sex", {}),
+        "statefips": select_opts.get("statefips", {}),
+        "datatype": select_opts.get("datatype", {}),
+    }
+
+
+def _label(options: dict[str, str], key: str) -> str:
+    return options.get(key, key)
+
+
+def get_risk_table(
+    topic: str,
+    risk: str,
+    race: str = "00",
+    sex: str = "0",
+    statefips: str = "00",
+    datatype: str = "0",
+    options: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Fetch a single risk-factor CSV and return it as a normalized DataFrame.
+
+    ``statefips="00"`` returns US-by-state, ``"99"`` returns US-by-county.
+    Other values return the counties of a single state.
+    """
+    url = (
+        f"{RISK_BASE_URL}?statefips={statefips}&topic={topic}&race={race}"
+        f"&sex={sex}&risk={risk}&type=risk&datatype={datatype}"
+        f"&sortVariableName=percent&sortOrder=desc&output=1"
+    )
+    logger.debug(url)
+
+    df = pd.read_csv(
+        url,
+        skiprows=8,
+        low_memory=False,
+        na_values=["*", "N/A", " N/A", "N/A ", " N/A "],
+        skipinitialspace=True,
+        dtype={"FIPS": str},
+    )
+    df.columns = [column_text_replace(c) for c in df.columns]
+
+    # Locale column is `state` for statefips=00, `county` for statefips=99 or
+    # a specific state. Normalize to `reported_locale` so downstream consumers
+    # don't have to branch.
+    if "state" in df.columns:
+        df = df.rename(columns={"state": "reported_locale"})
+    elif "county" in df.columns:
+        df = df.rename(columns={"county": "reported_locale"})
+
+    df = df.rename(
+        columns={
+            "percent2": "percent",
+            "lower_95pct_confidence_interval": "lower_ci_percent",
+            "upper_95pct_confidence_interval": "upper_ci_percent",
+            "number_of_respondents_with_screening_or_risk_factor": "respondents",
+        }
+    )
+
+    opts = options or {}
+    df["topic"] = topic
+    df["topic_label"] = _label(opts.get("topic", {}), topic)
+    df["risk"] = risk
+    df["risk_label"] = _label(opts.get("risk_by_topic", {}).get(topic, {}), risk)
+    df["race"] = _label(opts.get("race", {}), race)
+    df["sex"] = _label(opts.get("sex", {}), sex)
+    df["datatype"] = _label(opts.get("datatype", {}), datatype)
+    df["statefips_query"] = statefips
+
+    df.loc[df["fips"].isna(), "fips"] = ""
+    df["state_fips"] = df["fips"].str[:2]
+    df["locale_type"] = "other"
+    df.loc[df["fips"].str.startswith("00"), "locale_type"] = "national"
+    df.loc[df["fips"].str.endswith("000") & ~df["fips"].str.startswith("00"), "locale_type"] = "state"
+    if statefips == "99" or statefips not in ("00", ""):
+        # The county-level breakdown uses 5-digit county FIPS that don't end
+        # in 000; mark them as county.
+        df.loc[
+            df["fips"].str.len().eq(5) & ~df["fips"].str.endswith("000"),
+            "locale_type",
+        ] = "county"
+
+    df["_extracted_at"] = pd.Timestamp.now().isoformat()
+    df["url"] = url.replace("&output=1", "")
+
+    for numeric_column in ("percent", "lower_ci_percent", "upper_ci_percent", "respondents"):
+        if numeric_column in df.columns:
+            df[numeric_column] = pd.to_numeric(df[numeric_column], errors="coerce")
+
+    return df
+
+
+def risk_master_table(
+    statefipses: Iterable[str] = ("00", "99"),
+    options: dict[str, Any] | None = None,
+) -> pd.DataFrame:
+    """Iterate over every ``(topic, risk, race, sex, statefips)`` combination.
+
+    Parameters
+    ----------
+    statefipses : iterable of str
+        Which statefips queries to run. ``"00"`` returns the US-by-state
+        breakdown and ``"99"`` returns US-by-county. Defaults to both.
+    options : dict, optional
+        Pre-fetched output of ``get_risk_options()``. Refetched if omitted.
+    """
+    opts = options or get_risk_options()
+    dflist: list[pd.DataFrame] = []
+
+    topics = opts["topic"]
+    risk_by_topic = opts["risk_by_topic"]
+    races = opts["race"]
+    sexes = opts["sex"]
+
+    logger.info("Risk scrape: %d topics, statefips=%s", len(topics), list(statefipses))
+
+    for statefips in statefipses:
+        for topic_id in topics:
+            risks = risk_by_topic.get(topic_id, {})
+            if not risks:
+                logger.debug("No risks defined for topic %s; skipping", topic_id)
+                continue
+            for risk_id in risks:
+                for race_id in races:
+                    for sex_id in sexes:
+                        try:
+                            df = get_risk_table(
+                                topic=topic_id,
+                                risk=risk_id,
+                                race=race_id,
+                                sex=sex_id,
+                                statefips=statefips,
+                                options=opts,
+                            )
+                            dflist.append(df)
+                        except KeyboardInterrupt:
+                            raise
+                        except Exception as exc:
+                            logger.debug(
+                                "Skipped %s/%s race=%s sex=%s statefips=%s: %s",
+                                topic_id, risk_id, race_id, sex_id, statefips, exc,
+                            )
+
+    if not dflist:
+        return pd.DataFrame()
+    return pd.concat(dflist, ignore_index=True)

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -279,26 +279,16 @@ def master_table(
 
 
 def main():
-    import json
+    """Run the full scrape (incidence, mortality, risk, demographics).
 
-    logger.info("Getting select options")
-    json.dump(get_select_options(), open("select_options.json", "w"))
+    Kept as a thin wrapper around the click CLI so that
+    ``python -m scps.scraper`` and ``scps-scraper scrape`` produce the same
+    output set.
+    """
+    from scps.cli import cli
 
-    # Iterate county + state so downstream consumers get state rollups and
-    # the national row (FIPS 00000) in the same file. HSA is intentionally
-    # omitted from the default release run — it uses a non-FIPS area key
-    # and most downstream joins assume county/state FIPS.
-    default_areatypes = ("county", "state")
-
-    logger.info("Getting incidence data (areatypes=%s)", default_areatypes)
-    df = master_table(_type="incd", areatypes=default_areatypes)
-    logger.info("Saving incidence data with shape: %s", str(df.shape))
-    df.to_csv("state_cancer_profiles_incidence.csv.gz", index=False, compression="gzip")
-    logger.info("Getting death data (areatypes=%s)", default_areatypes)
-    df = master_table(_type="death", areatypes=default_areatypes)
-    logger.info("Saving mortality data with shape: %s", str(df.shape))
-    df.to_csv("state_cancer_profiles_mortality.csv.gz", index=False, compression="gzip")
+    cli(args=["scrape"], standalone_mode=False)
 
 
 if __name__ == "__main__":
-    print(main())
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Pre-import the scps.scraper module under a mocked httpx.get.
+
+``scps.scraper.get_select_options()`` runs at module import time and would
+otherwise hit the live State Cancer Profiles website. We force the import
+here, with httpx patched, before any test module loads. After the import,
+the patch is released so individual tests can patch httpx themselves.
+"""
+
+from unittest.mock import MagicMock, patch
+
+MOCK_SELECT_HTML = """
+<html>
+<body>
+  <select id="cancer">
+    <option value="001">All Cancer Sites</option>
+    <option value="071">Bladder</option>
+  </select>
+  <select id="year">
+    <option value="0">Latest 5-year average</option>
+  </select>
+  <select id="race">
+    <option value="00">All Races (includes Hispanic)</option>
+  </select>
+  <select id="sex">
+    <option value="0">Both Sexes</option>
+    <option value="1">Male</option>
+    <option value="2">Female</option>
+  </select>
+  <select id="age">
+    <option value="001">All Ages</option>
+  </select>
+  <select id="stage">
+    <option value="999">All Stages</option>
+  </select>
+  <select id="areatype">
+    <option value="county">By County</option>
+    <option value="state">By State/Registry/Division</option>
+  </select>
+</body>
+</html>
+"""
+
+_mock_response = MagicMock()
+_mock_response.text = MOCK_SELECT_HTML
+
+_httpx_patch = patch("httpx.get", return_value=_mock_response)
+_httpx_patch.start()
+try:
+    import scps.scraper  # noqa: F401  (force module load while patched)
+finally:
+    _httpx_patch.stop()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,77 @@
+"""Smoke tests for the click CLI."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+from click.testing import CliRunner
+
+from scps import cli
+
+
+def _fake_master_table(*_args, **_kwargs):
+    return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+
+def _fake_risk_table(*_args, **_kwargs):
+    return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+
+def _fake_demo_table(*_args, **_kwargs):
+    return pd.DataFrame({"reported_locale": ["X"], "area_code": ["00000"]})
+
+
+def test_cli_help_runs():
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["--help"])
+    assert result.exit_code == 0
+    assert "scrape" in result.output
+
+
+def test_scrape_writes_each_dataset(tmp_path):
+    runner = CliRunner()
+    with (
+        patch("scps.cli.scraper.master_table", side_effect=_fake_master_table),
+        patch("scps.cli.risk.risk_master_table", side_effect=_fake_risk_table),
+        patch(
+            "scps.cli.demographics.demographics_master_table",
+            side_effect=_fake_demo_table,
+        ),
+        patch("scps.cli.scraper.get_select_options", return_value={"cancer": {}}),
+    ):
+        result = runner.invoke(
+            cli.cli, ["scrape", "-o", str(tmp_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    expected_files = {
+        "state_cancer_profiles_incidence.csv.gz",
+        "state_cancer_profiles_mortality.csv.gz",
+        "state_cancer_profiles_risk.csv.gz",
+        "state_cancer_profiles_demographics.csv.gz",
+        "select_options.json",
+    }
+    written = {p.name for p in tmp_path.iterdir()}
+    assert expected_files <= written
+
+
+def test_scrape_filters_by_dataset(tmp_path):
+    runner = CliRunner()
+    with (
+        patch("scps.cli.scraper.master_table", side_effect=_fake_master_table),
+        patch("scps.cli.risk.risk_master_table", side_effect=_fake_risk_table) as risk_mock,
+        patch(
+            "scps.cli.demographics.demographics_master_table",
+            side_effect=_fake_demo_table,
+        ) as demo_mock,
+        patch("scps.cli.scraper.get_select_options", return_value={"cancer": {}}),
+    ):
+        result = runner.invoke(
+            cli.cli, ["scrape", "-d", "risk", "-o", str(tmp_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    risk_mock.assert_called_once()
+    demo_mock.assert_not_called()
+    assert (tmp_path / "state_cancer_profiles_risk.csv.gz").exists()
+    assert not (tmp_path / "state_cancer_profiles_incidence.csv.gz").exists()

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,0 +1,268 @@
+"""Tests for the scps.demographics module."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from scps import demographics
+
+
+# ---------------------------------------------------------------------------
+# parse_census_defines
+# ---------------------------------------------------------------------------
+
+SAMPLE_CENSUS_JS = """
+var population_ages_array = new Array();
+population_ages_array['00002'] = "Ages under 18";
+population_ages_array['00003'] = "Ages 65 and over";
+
+var population_races_array = new Array();
+population_races_array['00014'] = "Foreign born";
+population_races_array['00022'] = "Black";
+
+var pop_array = new Array();
+pop_array['Ages'] = population_ages_array;
+pop_array['Races'] = population_races_array;
+
+var ed_array = new Array();
+ed_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
+ed_array['00004']="Less than 9th grade";
+//ed_array['00005']="Less than high school";
+ed_array['00006']="At least bachelor's degree";
+
+var crowd_array = new Array();
+crowd_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
+crowd_array['00027']="Households with >1 person per room";
+"""
+
+
+def test_parse_census_defines_returns_topic_to_demo_mapping():
+    result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
+    assert result["ed"] == {
+        "00004": "Less than 9th grade",
+        "00006": "At least bachelor's degree",
+    }
+    assert result["crowd"] == {"00027": "Households with >1 person per room"}
+
+
+def test_parse_census_defines_merges_population_subarrays_into_pop():
+    """pop_array re-exports population_ages_array + population_races_array."""
+    result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
+    assert result["pop"] == {
+        "00002": "Ages under 18",
+        "00003": "Ages 65 and over",
+        "00014": "Foreign born",
+        "00022": "Black",
+    }
+
+
+def test_parse_census_defines_skips_comments_and_placeholders():
+    result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
+    # Commented "00005" line excluded.
+    assert "00005" not in result.get("ed", {})
+    # Placeholder "*****" excluded.
+    assert "*****" not in result.get("ed", {})
+
+
+def test_parse_census_defines_skips_block_commented_arrays():
+    """The live JS has `var ur_array = ...` inside /* ... */; must be skipped."""
+    js_with_block_comment = SAMPLE_CENSUS_JS + """
+/*
+var ur_array = new Array();
+ur_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
+ur_array['00001']="Continuum Code";
+*/
+"""
+    result = demographics.parse_census_defines(js_with_block_comment)
+    assert "ur" not in result
+
+
+def test_parse_census_defines_excludes_topic_box_array():
+    """`topic_box_array` is the topic-label lookup, not a topic definition."""
+    js_with_topic_box = SAMPLE_CENSUS_JS + """
+var topic_box_array = new Array();
+topic_box_array["crowd"] = "Crowding";
+topic_box_array["ed"] = "Education";
+"""
+    result = demographics.parse_census_defines(js_with_topic_box)
+    assert "topic_box" not in result
+
+
+# ---------------------------------------------------------------------------
+# get_demographics_table URL construction & normalization
+# ---------------------------------------------------------------------------
+
+def _fake_county_csv_dataframe():
+    return pd.DataFrame(
+        {
+            "county": ["United States", "Some County, TX"],
+            "fips": ["00000", "48001"],
+            "2023_rural_urban_continuum_codesrural_urban_note": ["N/A", "Rural"],
+            "value_percent": [3.4, 0.5],
+            "households_with_1_person_per_room": [4449577, 12],
+            "rank_within_us": ["N/A", "100 of 3143"],
+        }
+    )
+
+
+def _fake_hsa_csv_dataframe():
+    return pd.DataFrame(
+        {
+            "health_service_area": ["United States", "Jackson, CO"],
+            "hsa_code": ["00000", "0771"],
+            "value_percent": [3.4, 0.0],
+            "households_with_1_person_per_room": [4449577, 0],
+            "rank_within_us": ["N/A", "1 of 950"],
+        }
+    )
+
+
+def test_get_demographics_table_builds_expected_url():
+    captured = []
+
+    def fake_read_csv(url, **_kwargs):
+        captured.append(url)
+        return _fake_county_csv_dataframe()
+
+    with patch("pandas.read_csv", side_effect=fake_read_csv):
+        demographics.get_demographics_table(
+            topic="crowd", demo="00027", areatype="county"
+        )
+
+    assert len(captured) == 1
+    url = captured[0]
+    assert "topic=crowd" in url
+    assert "demo=00027" in url
+    assert "areatype=county" in url
+    assert "type=manyareacensus" in url
+    assert "output=1" in url
+
+
+def test_get_demographics_table_normalizes_county_columns():
+    with patch("pandas.read_csv", return_value=_fake_county_csv_dataframe()):
+        df = demographics.get_demographics_table(
+            topic="crowd", demo="00027", areatype="county"
+        )
+
+    assert "reported_locale" in df.columns
+    assert "area_code" in df.columns
+    assert "percent" in df.columns
+    assert "rank" in df.columns
+    # locale_type derived: 00000 is national, 5-digit county FIPS → county.
+    locale_types = dict(zip(df["area_code"], df["locale_type"]))
+    assert locale_types["00000"] == "national"
+    assert locale_types["48001"] == "county"
+
+
+def test_get_demographics_table_normalizes_hsa_columns():
+    """HSA areatype uses ``Health Service Area`` / ``HSA_Code`` headers."""
+    with patch("pandas.read_csv", return_value=_fake_hsa_csv_dataframe()):
+        df = demographics.get_demographics_table(
+            topic="crowd", demo="00027", areatype="hsa"
+        )
+
+    assert "reported_locale" in df.columns
+    assert "area_code" in df.columns
+    locale_types = dict(zip(df["area_code"], df["locale_type"]))
+    assert locale_types["00000"] == "national"
+    assert locale_types["0771"] == "hsa"
+
+
+# ---------------------------------------------------------------------------
+# demographics_master_table iteration
+# ---------------------------------------------------------------------------
+
+def _tiny_demo_options():
+    return {
+        "topic": {"crowd": "Crowding", "ed": "Education"},
+        "demo_by_topic": {
+            "crowd": {"00027": "Households with >1 person per room"},
+            "ed": {"00004": "Less than 9th grade"},
+        },
+        "areatype": {"county": "By County", "state": "By State"},
+        "race": {"00": "All Races"},
+        "sex": {"0": "Both Sexes"},
+        "age": {"001": "All Ages"},
+        "statefips": {"00": "United States"},
+    }
+
+
+def test_demographics_master_table_iterates_areatypes():
+    seen = []
+
+    def fake_get_table(**kwargs):
+        seen.append((kwargs["areatype"], kwargs["topic"], kwargs["demo"]))
+        return pd.DataFrame({"reported_locale": ["X"], "area_code": ["00000"]})
+
+    with patch.object(demographics, "get_demographics_table", side_effect=fake_get_table):
+        demographics.demographics_master_table(
+            areatypes=("county", "state"), options=_tiny_demo_options()
+        )
+
+    # 2 areatypes × 2 topics × 1 demo × 1 race × 1 sex × 1 age = 4 calls
+    assert len(seen) == 4
+    assert {a for a, _, _ in seen} == {"county", "state"}
+
+
+def test_demographics_master_table_default_areatypes_are_county_and_state():
+    """HSA is omitted by default — non-FIPS area code breaks downstream joins."""
+    seen_areatypes = set()
+
+    def fake_get_table(**kwargs):
+        seen_areatypes.add(kwargs["areatype"])
+        return pd.DataFrame({"reported_locale": ["X"], "area_code": ["00000"]})
+
+    with patch.object(demographics, "get_demographics_table", side_effect=fake_get_table):
+        demographics.demographics_master_table(options=_tiny_demo_options())
+
+    assert seen_areatypes == {"county", "state"}
+
+
+def test_demographics_master_table_swallows_failures():
+    def fake_get_table(**kwargs):
+        if kwargs["topic"] == "ed":
+            raise ValueError("simulated")
+        return pd.DataFrame({"reported_locale": ["X"], "area_code": ["00000"]})
+
+    with patch.object(demographics, "get_demographics_table", side_effect=fake_get_table):
+        df = demographics.demographics_master_table(
+            areatypes=("county",), options=_tiny_demo_options()
+        )
+
+    # Only crowd survives.
+    assert len(df) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_demographics_options live discovery
+# ---------------------------------------------------------------------------
+
+def test_get_demographics_options_combines_html_and_js():
+    html_response = MagicMock()
+    html_response.text = """
+    <html><body>
+      <select id="topic"><option value="crowd">Crowding</option></select>
+      <select id="areatype"><option value="county">By County</option></select>
+      <select id="race"><option value="00">All Races</option></select>
+      <select id="sex"><option value="0">Both Sexes</option></select>
+      <select id="age"><option value="001">All Ages</option></select>
+      <select id="statefips"><option value="00">United States</option></select>
+    </body></html>
+    """
+    js_response = MagicMock()
+    js_response.text = SAMPLE_CENSUS_JS
+
+    def fake_get(url, *_a, **_k):
+        if url.endswith(".js"):
+            return js_response
+        return html_response
+
+    with patch("scps.demographics.httpx.get", side_effect=fake_get):
+        opts = demographics.get_demographics_options()
+
+    assert opts["topic"] == {"crowd": "Crowding"}
+    assert opts["demo_by_topic"]["crowd"] == {
+        "00027": "Households with >1 person per room"
+    }
+    assert opts["areatype"] == {"county": "By County"}

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,243 @@
+"""Tests for the scps.risk module."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from scps import risk
+
+
+# ---------------------------------------------------------------------------
+# parse_risk_defines
+# ---------------------------------------------------------------------------
+
+SAMPLE_RISK_JS = """
+var alcohol_array = new Array();
+alcohol_array['**']=CHOOSE_BEGINNING + "choose screening or risk factor" + CHOOSE_END;
+alcohol_array['v505']="Binge drinking, ages 21+";
+//alcohol_array['v501']="Mean number of alcoholic drinks per day, ages 21+";
+
+var smoke_array = new Array();
+smoke_array['**']=CHOOSE_BEGINNING + "choose screening or risk factor" + CHOOSE_END;
+smoke_array["v19"]="Current Smoking; Ages 18+";
+smoke_array["v28"]="Smokers (Ever); Ages 18+";
+
+var topic_arrays = new Array();
+topic_arrays["alcohol"] = alcohol_array;
+topic_arrays["smoke"] = smoke_array;
+"""
+
+
+def test_parse_risk_defines_returns_topic_to_risk_mapping():
+    result = risk.parse_risk_defines(SAMPLE_RISK_JS)
+    assert result == {
+        "alcohol": {"v505": "Binge drinking, ages 21+"},
+        "smoke": {
+            "v19": "Current Smoking; Ages 18+",
+            "v28": "Smokers (Ever); Ages 18+",
+        },
+    }
+
+
+def test_parse_risk_defines_skips_commented_lines():
+    result = risk.parse_risk_defines(SAMPLE_RISK_JS)
+    # v501 is commented out and must not appear.
+    assert "v501" not in result.get("alcohol", {})
+
+
+def test_parse_risk_defines_skips_placeholder_choice_entries():
+    result = risk.parse_risk_defines(SAMPLE_RISK_JS)
+    assert "**" not in result.get("alcohol", {})
+    assert "**" not in result.get("smoke", {})
+
+
+# ---------------------------------------------------------------------------
+# get_risk_table URL construction & metadata enrichment
+# ---------------------------------------------------------------------------
+
+def _fake_risk_csv_dataframe():
+    return pd.DataFrame(
+        {
+            "state": ["United States", "District of Columbia", "Montana"],
+            "fips": ["00000", "11001", "30000"],
+            "percent2": [15.6, 25.5, 20.3],
+            "lower_95pct_confidence_interval": [pd.NA, 23.5, 18.9],
+            "upper_95pct_confidence_interval": [pd.NA, 27.6, 21.6],
+            "number_of_respondents_with_screening_or_risk_factor": [pd.NA, 536, 946],
+        }
+    )
+
+
+def test_get_risk_table_builds_expected_url():
+    captured = []
+
+    def fake_read_csv(url, **_kwargs):
+        captured.append(url)
+        return _fake_risk_csv_dataframe()
+
+    with patch("pandas.read_csv", side_effect=fake_read_csv):
+        risk.get_risk_table(topic="alcohol", risk="v505", statefips="00")
+
+    assert len(captured) == 1
+    url = captured[0]
+    assert "topic=alcohol" in url
+    assert "risk=v505" in url
+    assert "statefips=00" in url
+    assert "type=risk" in url
+    assert "output=1" in url
+
+
+def test_get_risk_table_normalizes_columns_and_adds_metadata():
+    options = {
+        "topic": {"alcohol": "Alcohol"},
+        "risk_by_topic": {"alcohol": {"v505": "Binge drinking"}},
+        "race": {"00": "All Races"},
+        "sex": {"0": "Both Sexes"},
+        "datatype": {"0": "Direct Estimates"},
+    }
+    with patch("pandas.read_csv", return_value=_fake_risk_csv_dataframe()):
+        df = risk.get_risk_table(
+            topic="alcohol", risk="v505", statefips="00", options=options
+        )
+
+    # Locale column renamed.
+    assert "reported_locale" in df.columns
+    # Percent column normalized.
+    assert "percent" in df.columns
+    # Metadata columns attached.
+    assert (df["topic_label"] == "Alcohol").all()
+    assert (df["risk_label"] == "Binge drinking").all()
+    assert (df["race"] == "All Races").all()
+    # locale_type derived from FIPS pattern.
+    locale_types = dict(zip(df["fips"], df["locale_type"]))
+    assert locale_types["00000"] == "national"
+    assert locale_types["30000"] == "state"  # ends in 000, not in 00
+
+
+def test_get_risk_table_county_breakdown_uses_county_column():
+    county_df = pd.DataFrame(
+        {
+            "county": ["Some County, TX"],
+            "fips": ["48001"],
+            "percent2": [10.0],
+            "lower_95pct_confidence_interval": [9.0],
+            "upper_95pct_confidence_interval": [11.0],
+            "number_of_respondents_with_screening_or_risk_factor": [42],
+        }
+    )
+    with patch("pandas.read_csv", return_value=county_df):
+        df = risk.get_risk_table(topic="alcohol", risk="v505", statefips="99")
+
+    assert "reported_locale" in df.columns
+    assert df["locale_type"].iloc[0] == "county"
+
+
+# ---------------------------------------------------------------------------
+# risk_master_table iteration
+# ---------------------------------------------------------------------------
+
+def _tiny_risk_options():
+    return {
+        "topic": {"alcohol": "Alcohol", "smoke": "Smoking"},
+        "risk_by_topic": {
+            "alcohol": {"v505": "Binge drinking"},
+            "smoke": {"v19": "Current smoking"},
+        },
+        "race": {"00": "All Races"},
+        "sex": {"0": "Both Sexes"},
+        "statefips": {"00": "US by State", "99": "US by County"},
+        "datatype": {"0": "Direct Estimates"},
+    }
+
+
+def test_risk_master_table_iterates_full_cartesian():
+    seen = []
+
+    def fake_get_risk_table(**kwargs):
+        seen.append(
+            (kwargs["topic"], kwargs["risk"], kwargs["statefips"])
+        )
+        return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+    with patch.object(risk, "get_risk_table", side_effect=fake_get_risk_table):
+        risk.risk_master_table(
+            statefipses=("00", "99"), options=_tiny_risk_options()
+        )
+
+    # 2 statefips × 2 topics × 1 risk-per-topic × 1 race × 1 sex = 4 calls
+    assert len(seen) == 4
+    assert set(seen) == {
+        ("alcohol", "v505", "00"),
+        ("smoke", "v19", "00"),
+        ("alcohol", "v505", "99"),
+        ("smoke", "v19", "99"),
+    }
+
+
+def test_risk_master_table_swallows_invalid_combinations():
+    """Exceptions from a single combo should not abort the run."""
+    def fake_get_risk_table(**kwargs):
+        if kwargs["topic"] == "smoke":
+            raise ValueError("simulated invalid combo")
+        return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+    with patch.object(risk, "get_risk_table", side_effect=fake_get_risk_table):
+        df = risk.risk_master_table(
+            statefipses=("00",), options=_tiny_risk_options()
+        )
+
+    # Only the alcohol row survives; smoke raised and was swallowed.
+    assert len(df) == 1
+
+
+def test_risk_master_table_propagates_keyboard_interrupt():
+    def fake_get_risk_table(**_kwargs):
+        raise KeyboardInterrupt
+
+    with patch.object(risk, "get_risk_table", side_effect=fake_get_risk_table):
+        with pytest.raises(KeyboardInterrupt):
+            risk.risk_master_table(
+                statefipses=("00",), options=_tiny_risk_options()
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_risk_options (live discovery)
+# ---------------------------------------------------------------------------
+
+def test_get_risk_options_combines_html_and_js():
+    html_response = MagicMock()
+    html_response.text = """
+    <html><body>
+      <select id="topic">
+        <option value="alcohol">Alcohol</option>
+      </select>
+      <select id="race">
+        <option value="00">All Races</option>
+      </select>
+      <select id="sex">
+        <option value="0">Both Sexes</option>
+      </select>
+      <select id="statefips">
+        <option value="00">US by State</option>
+      </select>
+      <select id="datatype">
+        <option value="0">Direct Estimates</option>
+      </select>
+    </body></html>
+    """
+    js_response = MagicMock()
+    js_response.text = SAMPLE_RISK_JS
+
+    def fake_get(url, *_a, **_k):
+        if url.endswith(".js"):
+            return js_response
+        return html_response
+
+    with patch("scps.risk.httpx.get", side_effect=fake_get):
+        opts = risk.get_risk_options()
+
+    assert opts["topic"] == {"alcohol": "Alcohol"}
+    assert "alcohol" in opts["risk_by_topic"]
+    assert "v505" in opts["risk_by_topic"]["alcohol"]

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,50 +1,11 @@
 """Basic tests for the scps.scraper module."""
 
-import io
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Minimal HTML that mimics the state cancer profiles select options page.
-# get_select_options() is called at module import time, so we must patch
-# httpx.get *before* importing scps.scraper.
-MOCK_SELECT_HTML = """
-<html>
-<body>
-  <select id="cancer">
-    <option value="001">All Cancer Sites</option>
-    <option value="071">Bladder</option>
-  </select>
-  <select id="year">
-    <option value="0">Latest 5-year average</option>
-  </select>
-  <select id="race">
-    <option value="00">All Races (includes Hispanic)</option>
-  </select>
-  <select id="sex">
-    <option value="0">Both Sexes</option>
-    <option value="1">Male</option>
-    <option value="2">Female</option>
-  </select>
-  <select id="age">
-    <option value="001">All Ages</option>
-  </select>
-  <select id="stage">
-    <option value="999">All Stages</option>
-  </select>
-  <select id="areatype">
-    <option value="county">By County</option>
-    <option value="state">By State/Registry/Division</option>
-  </select>
-</body>
-</html>
-"""
-
-_mock_http_response = MagicMock()
-_mock_http_response.text = MOCK_SELECT_HTML
-
-with patch("httpx.get", return_value=_mock_http_response):
-    from scps import scraper
+from scps import scraper
+from tests.conftest import MOCK_SELECT_HTML
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -473,6 +485,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },
+    { name = "click" },
     { name = "httpx" },
     { name = "pandas" },
 ]
@@ -486,6 +499,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bs4", specifier = ">=0.0.2" },
+    { name = "click", specifier = ">=8.1" },
     { name = "httpx", specifier = ">=0.27.0,<0.28.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },


### PR DESCRIPTION
Closes the screening/risk-factors and demographics parts of #11.

## What's new

- **`scps/risk.py`** — scrapes `/risk/index.php` for BRFSS screening and risk-factor prevalence (alcohol, smoking, mammograms, colonoscopy, HPV vaccination, etc.). The risk-factor dropdown is populated by JS at runtime, so we parse `/risk/riskJSDefines.js` to discover the `topic → {risk_id: label}` mapping. ~44 risk factors across 7 topics.
- **`scps/demographics.py`** — scrapes `/demographics/index.php` for ACS-derived indicators (crowding, education, poverty, SVI, mobility, etc.). Parses `/demographics/censusJSDefines.js`, including the nested `pop_array['Ages']` / `pop_array['Races']` structure for population breakdowns. Handles `/* ... */` block-commented arrays (`ur_array`) and excludes the `topic_box_array` label-lookup so it isn't mistaken for a topic.
- **`scps/cli.py`** — click-based CLI with a `scrape` command taking `--datasets`/`-d` and `--output-dir`/`-o` flags. Installed as `scps-scraper` via `[project.scripts]`. Legacy `python -m scps.scraper` still works (it now delegates to the CLI).

## Outputs

Each release now ships four gzipped CSVs (was two):

| file | what |
| --- | --- |
| `state_cancer_profiles_incidence.csv.gz` | (unchanged) |
| `state_cancer_profiles_mortality.csv.gz` | (unchanged) |
| `state_cancer_profiles_risk.csv.gz` | **new** — screening + risk factors |
| `state_cancer_profiles_demographics.csv.gz` | **new** — ACS demographics |

All four cover county + state in the same file (distinguished by `locale_type`).

## Tests

- 44 passing (was 19). 25 new tests cover the parsers, URL construction, column normalization (including HSA areatype), master-table iteration, exception-swallowing, and CLI subset selection.
- `tests/conftest.py` pre-imports `scps.scraper` under a mocked `httpx` so individual test modules don't have to repeat the import-time patching dance. Side benefit: test suite is now 0.08s (was 9.47s — no real HTTP).
- Verified end-to-end against the live State Cancer Profiles site (single-table fetch for both endpoints).

## Test plan

- [x] `uv run pytest -q` → 44 passed
- [x] Live smoke test: `risk.get_risk_table(topic="alcohol", risk="v505")` returns 60 rows with expected columns
- [x] Live smoke test: `demographics.get_demographics_table(topic="crowd", demo="00027", areatype="state")` returns 58 rows
- [x] `scps-scraper --help` and `scps-scraper scrape --help` render
- [ ] CI green on this PR
- [ ] Next scheduled monthly release picks up risk + demographics CSVs

## Notes / follow-ups

- **Catalog (PR 2)**: full cartesian iteration with no skip logic is intentional for the first run — most invalid combos are fast 404-equivalents. PR 2 adds a `scrape_catalog.jsonl` artifact that memoizes the surviving combinations and limits subsequent runs to ~20% of the cartesian.
- **Polars**: kept pandas for consistency with `master_table`; switching would balloon scope. Good follow-up perf PR — `pd.concat([list_of_dfs])` is the obvious target.
- One demographics output column has a `>` character (`households_with_>1_person_per_room`) because the source CSV column does. Names vary per demo so we can't rename to a fixed schema without losing info.