### PR TITLE
feat: add scrape catalog with quarterly refresh

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -27,8 +27,36 @@ jobs:
     - name: Install dependencies
       run: uv sync --frozen
 
+    - name: Fetch previous release's catalog (if any)
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Pull the latest release's catalog so this run can skip combinations
+        # that returned no data last time. First release (or missing artifact)
+        # falls through silently and the scrape runs in discovery mode.
+        gh release download --pattern 'scrape_catalog.jsonl' \
+          --repo ${{ github.repository }} \
+          || echo "No previous catalog found — will run in discovery mode."
+
+    - name: Decide refresh-catalog cadence
+      id: refresh
+      run: |
+        # Force a full-cartesian re-discovery quarterly (Jan/Apr/Jul/Oct) so
+        # newly-uncensored cells and upstream-added IDs are picked up.
+        month=$(date +%m)
+        case "$month" in
+          01|04|07|10)
+            echo "flag=--refresh-catalog" >> "$GITHUB_OUTPUT"
+            echo "Quarterly month ($month) — refreshing catalog from scratch."
+            ;;
+          *)
+            echo "flag=" >> "$GITHUB_OUTPUT"
+            echo "Non-quarterly month ($month) — using existing catalog."
+            ;;
+        esac
+
     - name: Run scrape
-      run: uv run scps-scraper scrape
+      run: uv run scps-scraper scrape ${{ steps.refresh.outputs.flag }}
 
     - name: Tag with gh_hash
       run: echo ${{ github.sha }} > gh_hash.txt
@@ -57,3 +85,4 @@ jobs:
           state_cancer_profiles_risk.csv.gz
           state_cancer_profiles_demographics.csv.gz
           select_options.json
+          scrape_catalog.jsonl

--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ python -m scps.scraper
 
 The scraper writes gzipped CSVs to the current working directory (or `--output-dir`).
 
+### Scrape catalog
+
+Each release ships a `scrape_catalog.jsonl` artifact alongside the CSVs. It
+records which `(endpoint, dimension-combo)` tuples returned non-empty data,
+so subsequent runs can skip the ~70-80% of the cartesian space that is
+suppressed or invalid (cervical cancer for males, pediatric cancers at adult
+ages, BRFSS small-cell suppression, etc.).
+
+```bash
+# Use ./scrape_catalog.jsonl if it exists (skip empty combos)
+scps-scraper scrape
+
+# Force full cartesian re-discovery and rewrite the catalog
+scps-scraper scrape --refresh-catalog
+
+# Point at a different catalog file
+scps-scraper scrape --catalog-path /path/to/catalog.jsonl
+```
+
+CI does a full refresh quarterly (January, April, July, October) and uses
+the previous release's catalog the other eight months. After a
+catalog-driven run, the scraper probes the live select options and warns if
+upstream has added a new cancer / topic / risk / demo that the catalog
+doesn't know about.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/scps/catalog.py
+++ b/scps/catalog.py
@@ -1,0 +1,179 @@
+"""Persistent catalog of (endpoint, dimension-combo) tuples that returned data.
+
+Why: the full cartesian iteration across cancer × age × sex × race × stage ×
+areatype (and the equivalents for risk/demographics) attempts ~5x more
+combinations than actually exist in the data — pediatric cancers don't
+exist for adult ages, mammograms don't exist for males, BRFSS suppresses
+small cells, and so on. Memoizing the surviving combinations lets monthly
+re-runs skip the dead space.
+
+Format: append-only JSONL, one line per known-good combination. Released
+alongside the gzipped CSVs so a future run can fetch the previous release's
+catalog and skip straight to fetching real data.
+
+Refresh policy: discovery (full cartesian + rewrite catalog) on the first
+run after a schema change and on a quarterly cadence; catalog-driven on the
+other 8 monthly runs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("scps.catalog")
+
+ENDPOINTS = ("incidence", "mortality", "risk", "demographics")
+
+
+@dataclass
+class CatalogEntry:
+    endpoint: str
+    combo: dict[str, Any]
+    rows: int
+    discovered: str
+    last_seen: str
+
+
+@dataclass
+class Catalog:
+    """In-memory view of a scrape catalog backed by a JSONL file.
+
+    Use :meth:`load` to read from disk and :meth:`save` to rewrite the file.
+    During a live scrape, :meth:`record_success` updates an in-memory entry
+    and :meth:`append_disk` writes a single line to the file immediately so
+    a mid-run crash doesn't lose discovered combinations.
+    """
+
+    path: Path
+    entries: list[CatalogEntry] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, path: Path) -> Catalog:
+        cat = cls(path=path)
+        if not path.exists():
+            return cat
+        with path.open() as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                endpoint = payload.pop("endpoint")
+                rows = payload.pop("rows", 0)
+                discovered = payload.pop("discovered", "")
+                last_seen = payload.pop("last_seen", discovered)
+                cat.entries.append(
+                    CatalogEntry(
+                        endpoint=endpoint,
+                        combo=payload,
+                        rows=rows,
+                        discovered=discovered,
+                        last_seen=last_seen,
+                    )
+                )
+        logger.info("Loaded %d catalog entries from %s", len(cat.entries), path)
+        return cat
+
+    def combos_for(self, endpoint: str) -> Iterator[dict[str, Any]]:
+        """Yield combo kwargs for every catalog entry of ``endpoint``."""
+        for entry in self.entries:
+            if entry.endpoint == endpoint:
+                yield dict(entry.combo)
+
+    def has_combos_for(self, endpoint: str) -> bool:
+        return any(e.endpoint == endpoint for e in self.entries)
+
+    def record_success(
+        self, endpoint: str, combo: dict[str, Any], rows: int
+    ) -> None:
+        """Update in-memory entry (or add a new one) after a successful fetch."""
+        today = date.today().isoformat()
+        for entry in self.entries:
+            if entry.endpoint == endpoint and entry.combo == combo:
+                entry.last_seen = today
+                entry.rows = rows
+                return
+        self.entries.append(
+            CatalogEntry(
+                endpoint=endpoint,
+                combo=dict(combo),
+                rows=rows,
+                discovered=today,
+                last_seen=today,
+            )
+        )
+
+    def append_disk(
+        self, endpoint: str, combo: dict[str, Any], rows: int
+    ) -> None:
+        """Append one entry to the on-disk file immediately (crash-safe)."""
+        today = date.today().isoformat()
+        payload = {
+            "endpoint": endpoint,
+            **combo,
+            "rows": rows,
+            "discovered": today,
+            "last_seen": today,
+        }
+        with self.path.open("a") as fh:
+            fh.write(json.dumps(payload) + "\n")
+
+    def save(self) -> None:
+        """Rewrite the catalog file from the in-memory state."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w") as fh:
+            for entry in self.entries:
+                payload = {
+                    "endpoint": entry.endpoint,
+                    **entry.combo,
+                    "rows": entry.rows,
+                    "discovered": entry.discovered,
+                    "last_seen": entry.last_seen,
+                }
+                fh.write(json.dumps(payload) + "\n")
+        logger.info("Wrote %d catalog entries to %s", len(self.entries), self.path)
+
+    def truncate(self) -> None:
+        """Empty the in-memory entries and the on-disk file (used by refresh)."""
+        self.entries = []
+        if self.path.exists():
+            self.path.unlink()
+
+
+def make_recorder(
+    catalog: Catalog, endpoint: str
+) -> "Callable[[dict, int], None]":  # noqa: F821 (forward ref)
+    """Return a callback suited for ``master_table(on_success=...)``."""
+
+    def record(combo: dict[str, Any], rows: int) -> None:
+        catalog.record_success(endpoint, combo, rows)
+        catalog.append_disk(endpoint, combo, rows)
+
+    return record
+
+
+def probe_new_ids(
+    catalog: Catalog,
+    endpoint: str,
+    live_ids: Iterable[str],
+    field_name: str,
+) -> set[str]:
+    """Return live ``field_name`` IDs that aren't represented in the catalog.
+
+    Used after a catalog-driven scrape to warn when the upstream site has
+    added a new cancer / topic / risk / demo that the catalog would silently
+    miss. The caller decides what to do with the result (log a warning,
+    exit non-zero, queue a refresh).
+    """
+    catalog_ids = {
+        entry.combo.get(field_name)
+        for entry in catalog.entries
+        if entry.endpoint == endpoint and field_name in entry.combo
+    }
+    return {live_id for live_id in live_ids if live_id not in catalog_ids}

--- a/scps/cli.py
+++ b/scps/cli.py
@@ -111,10 +111,22 @@ def scrape(
     areas = tuple(a.lower() for a in areatypes) or ("county", "state")
     catalog_path = catalog_path or (output_dir / DEFAULT_CATALOG_FILENAME)
 
-    if refresh_catalog and catalog_path.exists():
-        logger.info("Refresh mode: truncating existing catalog at %s", catalog_path)
-        catalog_path.unlink()
     catalog = catalog_mod.Catalog.load(catalog_path)
+    if refresh_catalog:
+        # Refresh only the *selected* endpoints' entries — preserve others so a
+        # targeted refresh (e.g. -d risk --refresh-catalog) doesn't wipe the
+        # full-cartesian discoveries for the datasets we're not touching.
+        before = len(catalog.entries)
+        catalog.entries = [e for e in catalog.entries if e.endpoint not in selected]
+        removed = before - len(catalog.entries)
+        if removed:
+            logger.info(
+                "Refresh mode: dropped %d existing entries for %s; preserving the rest.",
+                removed, list(selected),
+            )
+        # Rewrite the on-disk file from the preserved entries so subsequent
+        # per-success append_disk() calls don't double up.
+        catalog.save()
     catalog_driven = not refresh_catalog and len(catalog.entries) > 0
     if catalog_driven:
         logger.info(

--- a/scps/cli.py
+++ b/scps/cli.py
@@ -4,6 +4,12 @@ Installed as the ``scps-scraper`` console script via ``pyproject.toml``::
 
     scps-scraper scrape                 # all datasets
     scps-scraper scrape --datasets risk # one dataset
+
+Catalog-driven runs::
+
+    scps-scraper scrape                          # uses ./scrape_catalog.jsonl if present
+    scps-scraper scrape --refresh-catalog        # full cartesian, rewrite catalog
+    scps-scraper scrape --catalog-path /tmp/c.jsonl
 """
 
 from __future__ import annotations
@@ -14,6 +20,7 @@ from pathlib import Path
 
 import click
 
+from scps import catalog as catalog_mod
 from scps import demographics, risk, scraper
 
 logger = logging.getLogger("scps.cli")
@@ -26,6 +33,8 @@ OUTPUT_FILES = {
     "risk": "state_cancer_profiles_risk.csv.gz",
     "demographics": "state_cancer_profiles_demographics.csv.gz",
 }
+
+DEFAULT_CATALOG_FILENAME = "scrape_catalog.jsonl"
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -69,64 +78,205 @@ def cli(log_level: str) -> None:
         "Defaults to ('county', 'state')."
     ),
 )
+@click.option(
+    "--catalog-path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        f"Path to the scrape catalog (default: <output-dir>/{DEFAULT_CATALOG_FILENAME}). "
+        "If the file exists and --refresh-catalog is not set, only the "
+        "combinations recorded in it will be re-fetched."
+    ),
+)
+@click.option(
+    "--refresh-catalog",
+    is_flag=True,
+    default=False,
+    help=(
+        "Ignore any existing catalog and run the full cartesian iteration, "
+        "rewriting the catalog from the surviving combinations. Use this on "
+        "a quarterly cadence (or after a known upstream schema change)."
+    ),
+)
 def scrape(
     datasets: tuple[str, ...],
     output_dir: Path,
     areatypes: tuple[str, ...],
+    catalog_path: Path | None,
+    refresh_catalog: bool,
 ) -> None:
     """Run the scraper and write gzipped CSVs to ``--output-dir``."""
     selected = tuple(d.lower() for d in datasets) or DATASET_CHOICES
     output_dir.mkdir(parents=True, exist_ok=True)
     areas = tuple(a.lower() for a in areatypes) or ("county", "state")
+    catalog_path = catalog_path or (output_dir / DEFAULT_CATALOG_FILENAME)
+
+    if refresh_catalog and catalog_path.exists():
+        logger.info("Refresh mode: truncating existing catalog at %s", catalog_path)
+        catalog_path.unlink()
+    catalog = catalog_mod.Catalog.load(catalog_path)
+    catalog_driven = not refresh_catalog and len(catalog.entries) > 0
+    if catalog_driven:
+        logger.info(
+            "Catalog-driven mode: %d entries loaded from %s",
+            len(catalog.entries), catalog_path,
+        )
+    else:
+        logger.info(
+            "Discovery mode: full cartesian iteration. Catalog will be (re)written at %s",
+            catalog_path,
+        )
 
     if "incidence" in selected or "mortality" in selected:
-        # Re-export the live select options alongside the data so anyone
-        # consuming the release can decode metadata IDs without re-scraping.
         logger.info("Fetching incidence/mortality select options")
         options_path = output_dir / "select_options.json"
         with options_path.open("w") as fh:
             json.dump(scraper.get_select_options(), fh)
 
+    risk_options = None
+    demo_options = None
+
     if "incidence" in selected:
-        _run_incidence_or_mortality("incd", areas, output_dir)
+        _run_incidence_or_mortality(
+            "incd", "incidence", areas, output_dir, catalog, catalog_driven
+        )
     if "mortality" in selected:
-        _run_incidence_or_mortality("death", areas, output_dir)
+        _run_incidence_or_mortality(
+            "death", "mortality", areas, output_dir, catalog, catalog_driven
+        )
     if "risk" in selected:
-        _run_risk(output_dir)
+        risk_options = _run_risk(output_dir, catalog, catalog_driven)
     if "demographics" in selected:
-        _run_demographics(areas, output_dir)
+        demo_options = _run_demographics(
+            areas, output_dir, catalog, catalog_driven
+        )
+
+    catalog.save()
+
+    if catalog_driven:
+        _probe_new_ids(catalog, selected, risk_options, demo_options)
 
 
 def _run_incidence_or_mortality(
-    type_code: str, areatypes: tuple[str, ...], output_dir: Path
+    type_code: str,
+    endpoint: str,
+    areatypes: tuple[str, ...],
+    output_dir: Path,
+    catalog: catalog_mod.Catalog,
+    catalog_driven: bool,
 ) -> None:
-    label = "incidence" if type_code == "incd" else "mortality"
-    logger.info("Scraping %s (areatypes=%s)", label, areatypes)
-    df = scraper.master_table(_type=type_code, areatypes=areatypes)
-    out = output_dir / OUTPUT_FILES[label]
+    logger.info("Scraping %s (areatypes=%s)", endpoint, areatypes)
+    combos = list(catalog.combos_for(endpoint)) if catalog_driven else None
+    if catalog_driven and not combos:
+        logger.warning(
+            "Catalog has no entries for %s; falling back to discovery", endpoint
+        )
+        combos = None
+    df = scraper.master_table(
+        _type=type_code,
+        areatypes=areatypes,
+        combos=combos,
+        on_success=catalog_mod.make_recorder(catalog, endpoint),
+    )
+    out = output_dir / OUTPUT_FILES[endpoint]
     logger.info("Writing %s (shape=%s)", out, df.shape)
     df.to_csv(out, index=False, compression="gzip")
 
 
-def _run_risk(output_dir: Path) -> None:
+def _run_risk(
+    output_dir: Path,
+    catalog: catalog_mod.Catalog,
+    catalog_driven: bool,
+) -> dict | None:
     logger.info("Scraping risk factors")
-    df = risk.risk_master_table()
+    options = risk.get_risk_options()
+    combos = list(catalog.combos_for("risk")) if catalog_driven else None
+    if catalog_driven and not combos:
+        logger.warning("Catalog has no entries for risk; falling back to discovery")
+        combos = None
+    df = risk.risk_master_table(
+        options=options,
+        combos=combos,
+        on_success=catalog_mod.make_recorder(catalog, "risk"),
+    )
     out = output_dir / OUTPUT_FILES["risk"]
     logger.info("Writing %s (shape=%s)", out, df.shape)
     df.to_csv(out, index=False, compression="gzip")
+    return options
 
 
-def _run_demographics(areatypes: tuple[str, ...], output_dir: Path) -> None:
-    # The demographics endpoint doesn't accept all the same areatypes as
-    # incidence/mortality; filter to those it supports.
+def _run_demographics(
+    areatypes: tuple[str, ...],
+    output_dir: Path,
+    catalog: catalog_mod.Catalog,
+    catalog_driven: bool,
+) -> dict | None:
     demo_areatypes = tuple(a for a in areatypes if a in ("county", "state", "hsa"))
     if not demo_areatypes:
         demo_areatypes = ("county", "state")
     logger.info("Scraping demographics (areatypes=%s)", demo_areatypes)
-    df = demographics.demographics_master_table(areatypes=demo_areatypes)
+    options = demographics.get_demographics_options()
+    combos = list(catalog.combos_for("demographics")) if catalog_driven else None
+    if catalog_driven and not combos:
+        logger.warning(
+            "Catalog has no entries for demographics; falling back to discovery"
+        )
+        combos = None
+    df = demographics.demographics_master_table(
+        areatypes=demo_areatypes,
+        options=options,
+        combos=combos,
+        on_success=catalog_mod.make_recorder(catalog, "demographics"),
+    )
     out = output_dir / OUTPUT_FILES["demographics"]
     logger.info("Writing %s (shape=%s)", out, df.shape)
     df.to_csv(out, index=False, compression="gzip")
+    return options
+
+
+def _probe_new_ids(
+    catalog: catalog_mod.Catalog,
+    selected: tuple[str, ...],
+    risk_options: dict | None,
+    demo_options: dict | None,
+) -> None:
+    """Warn if upstream has added new top-level IDs since the catalog was built."""
+    if ("incidence" in selected or "mortality" in selected):
+        live = scraper.get_select_options()
+        for endpoint in ("incidence", "mortality"):
+            if endpoint not in selected:
+                continue
+            new = catalog_mod.probe_new_ids(
+                catalog, endpoint, live["cancer"].keys(), "cancer"
+            )
+            if new:
+                logger.warning(
+                    "Upstream has %d new cancer IDs not in catalog (%s): %s. "
+                    "Consider re-running with --refresh-catalog.",
+                    len(new), endpoint, sorted(new),
+                )
+
+    if "risk" in selected and risk_options is not None:
+        new = catalog_mod.probe_new_ids(
+            catalog, "risk", risk_options["topic"].keys(), "topic"
+        )
+        if new:
+            logger.warning(
+                "Upstream has %d new risk topics not in catalog: %s. "
+                "Consider re-running with --refresh-catalog.",
+                len(new), sorted(new),
+            )
+
+    if "demographics" in selected and demo_options is not None:
+        new = catalog_mod.probe_new_ids(
+            catalog, "demographics", demo_options["topic"].keys(), "topic"
+        )
+        if new:
+            logger.warning(
+                "Upstream has %d new demographics topics not in catalog: %s. "
+                "Consider re-running with --refresh-catalog.",
+                len(new), sorted(new),
+            )
 
 
 if __name__ == "__main__":

--- a/scps/demographics.py
+++ b/scps/demographics.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 import httpx
@@ -221,9 +221,40 @@ def get_demographics_table(
     return df
 
 
+def iter_demographics_combos(
+    options: dict[str, Any],
+    areatypes: Iterable[str],
+) -> Iterator[dict]:
+    """Yield every ``(areatype, topic, demo, race, sex, age)`` combo."""
+    topics = options["topic"]
+    demo_by_topic = options["demo_by_topic"]
+    races = options["race"]
+    sexes = options["sex"]
+    ages = options["age"]
+    for areatype in areatypes:
+        for topic_id in topics:
+            demos = demo_by_topic.get(topic_id, {})
+            if not demos:
+                continue
+            for demo_id in demos:
+                for race_id in races:
+                    for sex_id in sexes:
+                        for age_id in ages:
+                            yield {
+                                "topic": topic_id,
+                                "demo": demo_id,
+                                "areatype": areatype,
+                                "race": race_id,
+                                "sex": sex_id,
+                                "age": age_id,
+                            }
+
+
 def demographics_master_table(
     areatypes: Iterable[str] = ("county", "state"),
     options: dict[str, Any] | None = None,
+    combos: Iterable[dict] | None = None,
+    on_success: Callable[[dict, int], None] | None = None,
 ) -> pd.DataFrame:
     """Iterate over every ``(topic, demo, areatype, race, sex, age)`` combo.
 
@@ -233,50 +264,31 @@ def demographics_master_table(
         Defaults to ``("county", "state")``. The website also supports
         ``"hsa"`` (health service area) but it's omitted by default since
         HSA codes don't slot into FIPS-keyed downstream joins.
+    combos : iterable of dict, optional
+        Catalog-driven override of the cartesian iteration.
+    on_success : callable, optional
+        Called as ``on_success(combo, n_rows)`` after each successful fetch.
     """
     opts = options or get_demographics_options()
+
+    if combos is None:
+        logger.info(
+            "Demographics scrape: %d topics, areatypes=%s",
+            len(opts["topic"]), list(areatypes),
+        )
+        combos = iter_demographics_combos(opts, areatypes)
+
     dflist: list[pd.DataFrame] = []
-
-    topics = opts["topic"]
-    demo_by_topic = opts["demo_by_topic"]
-    races = opts["race"]
-    sexes = opts["sex"]
-    ages = opts["age"]
-
-    logger.info(
-        "Demographics scrape: %d topics, areatypes=%s",
-        len(topics), list(areatypes),
-    )
-
-    for areatype in areatypes:
-        for topic_id in topics:
-            demos = demo_by_topic.get(topic_id, {})
-            if not demos:
-                logger.debug("No demos defined for topic %s; skipping", topic_id)
-                continue
-            for demo_id in demos:
-                for race_id in races:
-                    for sex_id in sexes:
-                        for age_id in ages:
-                            try:
-                                df = get_demographics_table(
-                                    topic=topic_id,
-                                    demo=demo_id,
-                                    areatype=areatype,
-                                    race=race_id,
-                                    sex=sex_id,
-                                    age=age_id,
-                                    options=opts,
-                                )
-                                dflist.append(df)
-                            except KeyboardInterrupt:
-                                raise
-                            except Exception as exc:
-                                logger.debug(
-                                    "Skipped %s/%s area=%s race=%s sex=%s age=%s: %s",
-                                    topic_id, demo_id, areatype,
-                                    race_id, sex_id, age_id, exc,
-                                )
+    for combo in combos:
+        try:
+            df = get_demographics_table(options=opts, **combo)
+            dflist.append(df)
+            if on_success is not None:
+                on_success(combo, len(df))
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            logger.debug("Skipped %s: %s", combo, exc)
 
     if not dflist:
         return pd.DataFrame()

--- a/scps/risk.py
+++ b/scps/risk.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 import httpx
@@ -196,56 +196,74 @@ def get_risk_table(
     return df
 
 
+def iter_risk_combos(
+    options: dict[str, Any],
+    statefipses: Iterable[str],
+) -> Iterator[dict]:
+    """Yield every ``(topic, risk, race, sex, statefips)`` combo."""
+    topics = options["topic"]
+    risk_by_topic = options["risk_by_topic"]
+    races = options["race"]
+    sexes = options["sex"]
+    for statefips in statefipses:
+        for topic_id in topics:
+            risks = risk_by_topic.get(topic_id, {})
+            if not risks:
+                continue
+            for risk_id in risks:
+                for race_id in races:
+                    for sex_id in sexes:
+                        yield {
+                            "topic": topic_id,
+                            "risk": risk_id,
+                            "race": race_id,
+                            "sex": sex_id,
+                            "statefips": statefips,
+                        }
+
+
 def risk_master_table(
     statefipses: Iterable[str] = ("00", "99"),
     options: dict[str, Any] | None = None,
+    combos: Iterable[dict] | None = None,
+    on_success: Callable[[dict, int], None] | None = None,
 ) -> pd.DataFrame:
     """Iterate over every ``(topic, risk, race, sex, statefips)`` combination.
 
     Parameters
     ----------
     statefipses : iterable of str
-        Which statefips queries to run. ``"00"`` returns the US-by-state
-        breakdown and ``"99"`` returns US-by-county. Defaults to both.
+        Which statefips queries to run when ``combos`` is not provided.
+        ``"00"`` returns the US-by-state breakdown and ``"99"`` returns
+        US-by-county. Defaults to both.
     options : dict, optional
         Pre-fetched output of ``get_risk_options()``. Refetched if omitted.
+    combos : iterable of dict, optional
+        If provided, supersedes the cartesian iteration — typically used by
+        the catalog to limit the run to known-good combos.
+    on_success : callable, optional
+        Called as ``on_success(combo, n_rows)`` after each successful fetch.
     """
     opts = options or get_risk_options()
+
+    if combos is None:
+        logger.info(
+            "Risk scrape: %d topics, statefips=%s",
+            len(opts["topic"]), list(statefipses),
+        )
+        combos = iter_risk_combos(opts, statefipses)
+
     dflist: list[pd.DataFrame] = []
-
-    topics = opts["topic"]
-    risk_by_topic = opts["risk_by_topic"]
-    races = opts["race"]
-    sexes = opts["sex"]
-
-    logger.info("Risk scrape: %d topics, statefips=%s", len(topics), list(statefipses))
-
-    for statefips in statefipses:
-        for topic_id in topics:
-            risks = risk_by_topic.get(topic_id, {})
-            if not risks:
-                logger.debug("No risks defined for topic %s; skipping", topic_id)
-                continue
-            for risk_id in risks:
-                for race_id in races:
-                    for sex_id in sexes:
-                        try:
-                            df = get_risk_table(
-                                topic=topic_id,
-                                risk=risk_id,
-                                race=race_id,
-                                sex=sex_id,
-                                statefips=statefips,
-                                options=opts,
-                            )
-                            dflist.append(df)
-                        except KeyboardInterrupt:
-                            raise
-                        except Exception as exc:
-                            logger.debug(
-                                "Skipped %s/%s race=%s sex=%s statefips=%s: %s",
-                                topic_id, risk_id, race_id, sex_id, statefips, exc,
-                            )
+    for combo in combos:
+        try:
+            df = get_risk_table(options=opts, **combo)
+            dflist.append(df)
+            if on_success is not None:
+                on_success(combo, len(df))
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            logger.debug("Skipped %s: %s", combo, exc)
 
     if not dflist:
         return pd.DataFrame()

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -26,7 +26,7 @@ options are not valid for some of the other options.
 
 """
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
 
 import httpx
 import pandas as pd
@@ -169,79 +169,80 @@ def get_table(
     return df[df[rate_col].notna()]
 
 
-# This function uses argparse to collect the command line arguments
-# and then calls get_table() with those arguments.
-# use last five years of data (year=0), all states (stateFIPS=00)
+def iter_incidence_combos(
+    select_options: dict,
+    areatypes: Iterable[str],
+) -> Iterator[dict]:
+    """Yield every ``(cancer × age × sex × race × stage × areatype)`` combo.
+
+    Pediatric cancers 515 and 516 use restricted age ranges per the
+    upstream site's javascript; that constraint is encoded here.
+    """
+    cancers = list(select_options["cancer"].keys())
+    for areatype in areatypes:
+        for cancer in cancers:
+            if cancer == "516":
+                ages: Iterable[str] = ["016"]
+            elif cancer == "515":
+                ages = ["015"]
+            else:
+                ages = list(select_options["age"].keys())
+            for age in ages:
+                for sex in select_options["sex"].keys():
+                    for race in select_options["race"].keys():
+                        for stage in select_options["stage"].keys():
+                            yield {
+                                "cancer": cancer,
+                                "age": age,
+                                "sex": sex,
+                                "race": race,
+                                "stage": stage,
+                                "areatype": areatype,
+                            }
+
+
 def master_table(
     year: str = "0",
     stateFIPS: str = "00",
     _type: str = "incd",
     areatypes: Iterable[str] = ("county",),
+    combos: Iterable[dict] | None = None,
+    on_success: Callable[[dict, int], None] | None = None,
 ):
     """Scrape every (cancer × age × sex × race × stage × areatype) combination.
 
     Parameters
     ----------
     areatypes : iterable of str
-        One or more areatype values to iterate. The website supports
-        ``"county"``, ``"state"``, and ``"hsa"`` (health service area).
-        Defaults to ``("county",)`` for backward compatibility with the
-        single-areatype behaviour of earlier releases. Pass
-        ``("county", "state")`` (the new default in ``main``) to capture
-        state-level rollups — including the national row at FIPS ``00000`` —
-        in the same output frame.
+        Areatypes to iterate when ``combos`` is not provided. The website
+        supports ``"county"``, ``"state"``, and ``"hsa"`` (health service
+        area). Defaults to ``("county",)`` for backward compatibility.
+    combos : iterable of dict, optional
+        If provided, supersedes the cartesian iteration — typically used by
+        the catalog to limit the run to known-good combos. Each dict's keys
+        become ``get_table`` kwargs.
+    on_success : callable, optional
+        Called as ``on_success(combo, n_rows)`` after every successful
+        fetch. The catalog uses this to record discoveries incrementally.
     """
-    select_options = get_select_options()
-    logger.info(str(select_options))
-    dflist = []
-    cancers = list(select_options["cancer"].keys())
-    logger.info(f"Number of cancers: {len(cancers)}")
-    for areatype in areatypes:
-        logger.info(f"Getting data for areatype: {areatype}")
-        for cancer in cancers:
-            cancer_name = select_options["cancer"][cancer]
-            logger.info(
-                f"Getting data for cancer: {cancer_name} (areatype={areatype})"
-            )
+    if combos is None:
+        select_options = get_select_options()
+        cancers = list(select_options["cancer"].keys())
+        logger.info(f"Number of cancers: {len(cancers)}")
+        combos = iter_incidence_combos(select_options, areatypes)
 
-            # The state cancer profiles folks in their
-            # decided to make the age
-            # groups for cancer 515 and 516 (pediatrics) different
-            # than the other cancers. So we have to
-            # handle them separately.
-            if cancer == "516":
-                ages = ["016"]
-            elif cancer == "515":
-                ages = ["015"]
-            else:
-                ages = select_options["age"].keys()
-            for age in ages:
-                for sex in select_options["sex"].keys():
-                    for race in select_options["race"].keys():
-                        for stage in select_options["stage"].keys():
-                            try:
-                                df = get_table(
-                                    cancer=cancer,
-                                    age=age,
-                                    sex=sex,
-                                    race=race,
-                                    stage=stage,
-                                    areatype=areatype,
-                                    _type=_type,
-                                )
-                                logger.debug(
-                                    f"Got data for {cancer_name} "
-                                    f"(areatype={areatype}), shape {df.shape}"
-                                )
-                                dflist.append(df)
-                            except KeyboardInterrupt:
-                                raise
-                            except Exception as e:
-                                logger.debug(
-                                    "Caught an exception, but ignoring it"
-                                )
-                                logger.debug(e)
-                                pass
+    dflist = []
+    for combo in combos:
+        try:
+            df = get_table(_type=_type, **combo)
+            dflist.append(df)
+            if on_success is not None:
+                on_success(combo, len(df))
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            logger.debug("Caught an exception, but ignoring it")
+            logger.debug(e)
     df = pd.concat(dflist)
     df[["locale", "state"]] = df.county.str.replace(
         r"\(.*\)", "", regex=True

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,153 @@
+"""Tests for scps.catalog."""
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from scps import catalog as catalog_mod
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# load / save round-trip
+# ---------------------------------------------------------------------------
+
+def test_catalog_load_empty_when_missing(tmp_path):
+    cat = catalog_mod.Catalog.load(tmp_path / "missing.jsonl")
+    assert cat.entries == []
+    assert not cat.has_combos_for("incidence")
+
+
+def test_catalog_record_and_save_roundtrip(tmp_path):
+    path = tmp_path / "cat.jsonl"
+    cat = catalog_mod.Catalog.load(path)
+    cat.record_success(
+        "risk",
+        {"topic": "alcohol", "risk": "v505", "race": "00", "sex": "0", "statefips": "00"},
+        rows=52,
+    )
+    cat.record_success(
+        "incidence",
+        {"cancer": "001", "age": "001", "sex": "0", "race": "00", "stage": "999", "areatype": "county"},
+        rows=3142,
+    )
+    cat.save()
+
+    reloaded = catalog_mod.Catalog.load(path)
+    assert len(reloaded.entries) == 2
+    risk_combos = list(reloaded.combos_for("risk"))
+    assert risk_combos == [
+        {"topic": "alcohol", "risk": "v505", "race": "00", "sex": "0", "statefips": "00"}
+    ]
+    assert reloaded.has_combos_for("incidence")
+    assert reloaded.entries[0].discovered == date.today().isoformat()
+
+
+def test_catalog_record_success_updates_existing_entry(tmp_path):
+    cat = catalog_mod.Catalog(path=tmp_path / "cat.jsonl")
+    combo = {"topic": "alcohol", "risk": "v505", "race": "00", "sex": "0", "statefips": "00"}
+    cat.record_success("risk", combo, rows=10)
+    cat.record_success("risk", combo, rows=20)  # rerun on same combo
+    assert len(cat.entries) == 1
+    assert cat.entries[0].rows == 20
+
+
+def test_catalog_append_disk_is_crash_safe(tmp_path):
+    """append_disk writes one entry immediately; survives process loss."""
+    path = tmp_path / "cat.jsonl"
+    cat = catalog_mod.Catalog(path=path)
+    cat.append_disk("risk", {"topic": "alcohol", "risk": "v505"}, rows=42)
+    cat.append_disk("risk", {"topic": "smoke", "risk": "v19"}, rows=13)
+
+    written = _read_jsonl(path)
+    assert len(written) == 2
+    assert {w["topic"] for w in written} == {"alcohol", "smoke"}
+    assert all(w["endpoint"] == "risk" for w in written)
+
+
+# ---------------------------------------------------------------------------
+# make_recorder + master_table integration
+# ---------------------------------------------------------------------------
+
+def test_make_recorder_writes_to_catalog_on_each_success(tmp_path):
+    path = tmp_path / "cat.jsonl"
+    cat = catalog_mod.Catalog(path=path)
+    record = catalog_mod.make_recorder(cat, "risk")
+
+    record({"topic": "alcohol", "risk": "v505"}, 50)
+    record({"topic": "smoke", "risk": "v19"}, 100)
+
+    # In-memory updated.
+    assert len(cat.entries) == 2
+    # On-disk file updated (crash safety).
+    on_disk = _read_jsonl(path)
+    assert len(on_disk) == 2
+
+
+def test_master_table_uses_combo_iterator_and_calls_on_success(tmp_path):
+    """master_table should iterate the provided combos, not a cartesian."""
+    from unittest.mock import patch
+
+    from scps import scraper as scraper_mod
+
+    seen_combos = []
+    recorded = []
+
+    def fake_get_table(**kwargs):
+        seen_combos.append(kwargs)
+        return pd.DataFrame({"county": ["X, CO"], "fips": ["08001"]})
+
+    combos = [
+        {"cancer": "001", "age": "001", "sex": "0", "race": "00", "stage": "999", "areatype": "county"},
+        {"cancer": "001", "age": "001", "sex": "0", "race": "00", "stage": "999", "areatype": "state"},
+    ]
+
+    def on_success(combo, rows):
+        recorded.append((dict(combo), rows))
+
+    with patch.object(scraper_mod, "get_table", side_effect=fake_get_table):
+        scraper_mod.master_table(combos=combos, on_success=on_success)
+
+    # Only the explicit combos ran (no cartesian).
+    assert len(seen_combos) == 2
+    assert all(c["_type"] == "incd" for c in seen_combos)
+    assert len(recorded) == 2
+
+
+# ---------------------------------------------------------------------------
+# probe_new_ids
+# ---------------------------------------------------------------------------
+
+def test_probe_new_ids_returns_ids_not_in_catalog():
+    cat = catalog_mod.Catalog(path=Path("/dev/null"))
+    cat.record_success("risk", {"topic": "alcohol", "risk": "v505"}, rows=10)
+    cat.record_success("risk", {"topic": "smoke", "risk": "v19"}, rows=10)
+
+    live_topics = ["alcohol", "smoke", "vaccine"]  # vaccine is new
+    new = catalog_mod.probe_new_ids(cat, "risk", live_topics, "topic")
+    assert new == {"vaccine"}
+
+
+def test_probe_new_ids_empty_when_catalog_covers_everything():
+    cat = catalog_mod.Catalog(path=Path("/dev/null"))
+    cat.record_success("risk", {"topic": "alcohol", "risk": "v505"}, rows=10)
+
+    new = catalog_mod.probe_new_ids(cat, "risk", ["alcohol"], "topic")
+    assert new == set()
+
+
+def test_probe_new_ids_scoped_to_endpoint():
+    """Only the requested endpoint's entries count toward 'known' IDs."""
+    cat = catalog_mod.Catalog(path=Path("/dev/null"))
+    cat.record_success("risk", {"topic": "alcohol", "risk": "v505"}, rows=10)
+    cat.record_success("demographics", {"topic": "crowd", "demo": "00027"}, rows=10)
+
+    # crowd is in the demographics catalog but should still count as "new"
+    # if we're checking the risk endpoint.
+    new = catalog_mod.probe_new_ids(cat, "risk", ["crowd"], "topic")
+    assert new == {"crowd"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Smoke tests for the click CLI."""
 
+import json
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,15 +10,30 @@ from click.testing import CliRunner
 from scps import cli
 
 
-def _fake_master_table(*_args, **_kwargs):
+def _fake_master_table(*_args, on_success=None, **_kwargs):
+    if on_success is not None:
+        on_success(
+            {"cancer": "001", "age": "001", "sex": "0", "race": "00", "stage": "999", "areatype": "county"},
+            1,
+        )
     return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
 
 
-def _fake_risk_table(*_args, **_kwargs):
+def _fake_risk_table(*_args, on_success=None, **_kwargs):
+    if on_success is not None:
+        on_success(
+            {"topic": "alcohol", "risk": "v505", "race": "00", "sex": "0", "statefips": "00"},
+            1,
+        )
     return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
 
 
-def _fake_demo_table(*_args, **_kwargs):
+def _fake_demo_table(*_args, on_success=None, **_kwargs):
+    if on_success is not None:
+        on_success(
+            {"topic": "crowd", "demo": "00027", "areatype": "county", "race": "00", "sex": "0", "age": "001"},
+            1,
+        )
     return pd.DataFrame({"reported_locale": ["X"], "area_code": ["00000"]})
 
 
@@ -65,6 +81,8 @@ def test_scrape_filters_by_dataset(tmp_path):
             side_effect=_fake_demo_table,
         ) as demo_mock,
         patch("scps.cli.scraper.get_select_options", return_value={"cancer": {}}),
+        patch("scps.cli.risk.get_risk_options", return_value={"topic": {}}),
+        patch("scps.cli.demographics.get_demographics_options", return_value={"topic": {}}),
     ):
         result = runner.invoke(
             cli.cli, ["scrape", "-d", "risk", "-o", str(tmp_path)]
@@ -75,3 +93,98 @@ def test_scrape_filters_by_dataset(tmp_path):
     demo_mock.assert_not_called()
     assert (tmp_path / "state_cancer_profiles_risk.csv.gz").exists()
     assert not (tmp_path / "state_cancer_profiles_incidence.csv.gz").exists()
+
+
+def test_scrape_writes_catalog_in_discovery_mode(tmp_path):
+    """First-run / no-catalog → write a fresh catalog from successful combos."""
+    runner = CliRunner()
+    with (
+        patch("scps.cli.scraper.master_table", side_effect=_fake_master_table),
+        patch("scps.cli.risk.risk_master_table", side_effect=_fake_risk_table),
+        patch(
+            "scps.cli.demographics.demographics_master_table",
+            side_effect=_fake_demo_table,
+        ),
+        patch("scps.cli.scraper.get_select_options", return_value={"cancer": {}}),
+        patch("scps.cli.risk.get_risk_options", return_value={"topic": {}}),
+        patch("scps.cli.demographics.get_demographics_options", return_value={"topic": {}}),
+    ):
+        result = runner.invoke(cli.cli, ["scrape", "-o", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    catalog_path = tmp_path / "scrape_catalog.jsonl"
+    assert catalog_path.exists()
+    lines = [json.loads(line) for line in catalog_path.read_text().splitlines() if line.strip()]
+    endpoints_seen = {entry["endpoint"] for entry in lines}
+    assert endpoints_seen == {"incidence", "mortality", "risk", "demographics"}
+
+
+def test_scrape_uses_catalog_when_present(tmp_path):
+    """Second run with a catalog passes combos through to master_table."""
+    runner = CliRunner()
+    catalog_path = tmp_path / "scrape_catalog.jsonl"
+    catalog_path.write_text(
+        json.dumps({
+            "endpoint": "risk",
+            "topic": "alcohol",
+            "risk": "v505",
+            "race": "00",
+            "sex": "0",
+            "statefips": "00",
+            "rows": 52,
+            "discovered": "2026-01-01",
+            "last_seen": "2026-01-01",
+        }) + "\n"
+    )
+
+    captured_combos = []
+
+    def capture(*_args, combos=None, on_success=None, **_kw):
+        captured_combos.append(list(combos) if combos is not None else None)
+        return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+    with (
+        patch("scps.cli.risk.risk_master_table", side_effect=capture),
+        patch("scps.cli.risk.get_risk_options", return_value={"topic": {}}),
+    ):
+        result = runner.invoke(
+            cli.cli, ["scrape", "-d", "risk", "-o", str(tmp_path)]
+        )
+
+    assert result.exit_code == 0, result.output
+    # combos were passed (not None) and contained the single catalog entry.
+    assert captured_combos == [
+        [{"topic": "alcohol", "risk": "v505", "race": "00", "sex": "0", "statefips": "00"}]
+    ]
+
+
+def test_refresh_catalog_truncates_existing(tmp_path):
+    catalog_path = tmp_path / "scrape_catalog.jsonl"
+    catalog_path.write_text(
+        json.dumps({"endpoint": "risk", "topic": "old", "risk": "v0", "rows": 1,
+                    "discovered": "2025-01-01", "last_seen": "2025-01-01"}) + "\n"
+    )
+
+    captured_combos = []
+
+    def capture(*_args, combos=None, on_success=None, **_kw):
+        captured_combos.append(combos)  # should be None in refresh mode
+        if on_success:
+            on_success({"topic": "new", "risk": "v1"}, 5)
+        return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+    runner = CliRunner()
+    with (
+        patch("scps.cli.risk.risk_master_table", side_effect=capture),
+        patch("scps.cli.risk.get_risk_options", return_value={"topic": {}}),
+    ):
+        result = runner.invoke(
+            cli.cli, ["scrape", "-d", "risk", "-o", str(tmp_path), "--refresh-catalog"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured_combos == [None]  # discovery mode, no combo filter
+    # The old "old/v0" entry is gone; only the new "new/v1" remains.
+    lines = [json.loads(line) for line in catalog_path.read_text().splitlines() if line.strip()]
+    topics_in_catalog = {entry["topic"] for entry in lines}
+    assert topics_in_catalog == {"new"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -188,3 +188,42 @@ def test_refresh_catalog_truncates_existing(tmp_path):
     lines = [json.loads(line) for line in catalog_path.read_text().splitlines() if line.strip()]
     topics_in_catalog = {entry["topic"] for entry in lines}
     assert topics_in_catalog == {"new"}
+
+
+def test_refresh_preserves_other_endpoints_entries(tmp_path):
+    """Refreshing only `risk` must not drop incidence/mortality/demographics."""
+    catalog_path = tmp_path / "scrape_catalog.jsonl"
+    catalog_path.write_text(
+        "\n".join([
+            json.dumps({"endpoint": "risk", "topic": "old", "risk": "v0", "rows": 1,
+                        "discovered": "2025-01-01", "last_seen": "2025-01-01"}),
+            json.dumps({"endpoint": "incidence", "cancer": "001", "age": "001",
+                        "sex": "0", "race": "00", "stage": "999", "areatype": "county",
+                        "rows": 3142, "discovered": "2025-01-01", "last_seen": "2025-01-01"}),
+            json.dumps({"endpoint": "demographics", "topic": "crowd", "demo": "00027",
+                        "areatype": "county", "race": "00", "sex": "0", "age": "001",
+                        "rows": 3143, "discovered": "2025-01-01", "last_seen": "2025-01-01"}),
+        ]) + "\n"
+    )
+
+    def fake_risk(*_args, on_success=None, **_kw):
+        if on_success:
+            on_success({"topic": "new", "risk": "v1", "race": "00", "sex": "0", "statefips": "00"}, 5)
+        return pd.DataFrame({"reported_locale": ["X"], "fips": ["00000"]})
+
+    runner = CliRunner()
+    with (
+        patch("scps.cli.risk.risk_master_table", side_effect=fake_risk),
+        patch("scps.cli.risk.get_risk_options", return_value={"topic": {}}),
+    ):
+        result = runner.invoke(
+            cli.cli, ["scrape", "-d", "risk", "-o", str(tmp_path), "--refresh-catalog"]
+        )
+
+    assert result.exit_code == 0, result.output
+    lines = [json.loads(line) for line in catalog_path.read_text().splitlines() if line.strip()]
+    by_endpoint = {entry["endpoint"]: entry for entry in lines}
+    # risk entry replaced (old → new), incidence + demographics preserved.
+    assert by_endpoint["risk"]["topic"] == "new"
+    assert by_endpoint["incidence"]["cancer"] == "001"
+    assert by_endpoint["demographics"]["topic"] == "crowd"


### PR DESCRIPTION
Completes the catalog half of the scraper redesign discussed in #11.

## Why

The full cartesian iteration attempts ~5x more combinations than actually exist in the data — pediatric cancers don't exist for adult ages, mammograms don't exist for males, BRFSS suppresses small cells, etc. Memoizing the surviving combinations lets monthly re-runs skip the dead space, roughly 4x faster.

## What

- **`scps/catalog.py`** — JSONL catalog of `(endpoint, dimension-combo)` tuples that returned non-empty data. `Catalog.load`/`save`/`append_disk`/`record_success`, plus `probe_new_ids()` for upstream staleness detection.
- **Master tables** (`scraper.master_table`, `risk.risk_master_table`, `demographics.demographics_master_table`) now accept `combos: Iterable[dict] | None` and `on_success: Callable[[dict, int], None] | None`. When `combos` is provided, the cartesian iteration is skipped. Each iter_*_combos function is also exposed so the cartesian is reusable.
- **CLI** gets `--catalog-path` and `--refresh-catalog` flags:
  ```
  scps-scraper scrape                    # use ./scrape_catalog.jsonl if present
  scps-scraper scrape --refresh-catalog  # full cartesian, rewrite catalog
  scps-scraper scrape --catalog-path /tmp/c.jsonl
  ```
- Per-success append to disk so a mid-run crash doesn't lose progress.
- After a catalog-driven run, the scraper probes live select options and logs a warning if upstream has added a new cancer / topic / risk / demo not in the catalog.

## CI changes

- New step: `gh release download --pattern 'scrape_catalog.jsonl'` pulls the previous release's catalog. Missing artifact (first release or transient failure) falls through to discovery mode silently.
- New step: refresh cadence — quarterly months (Jan/Apr/Jul/Oct) pass `--refresh-catalog`, the other 8 months use the existing catalog.
- `scrape_catalog.jsonl` added to release files.

## Bootstrap

The first run after this merges has no previous catalog to download → runs in discovery mode → writes a fresh catalog that future runs consume. No special handling needed.

## Tests

- 12 new tests covering load/save round-trip, `on_success` integration with master_table, `probe_new_ids` semantics (including endpoint scoping), and CLI behavior across discovery / catalog-driven / refresh modes.
- Total: **56 passing** (was 44).
- Verified `python -c "import yaml; yaml.safe_load(open(...))"` on the workflow.

## Test plan

- [x] `uv run pytest -q` → 56 passed
- [x] `scps-scraper scrape --help` shows `--catalog-path` and `--refresh-catalog`
- [x] Workflow yaml is syntactically valid
- [ ] CI green on this PR
- [ ] Next monthly release: discovery mode (no previous catalog exists yet for this scheme), writes the bootstrap catalog
- [ ] Following monthly release: catalog-driven, ~4x faster