### PR TITLE
fix: classify state-areatype rows and county-equivalents correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ state_cancer_profiles_incidence.csv.gz
 state_cancer_profiles_incidence.csv
 state_cancer_profiles_select_options.json
 state_cancer_profiles_mortality.csv.gz
+state_cancer_profiles_risk.csv.gz
+state_cancer_profiles_demographics.csv.gz
+scrape_catalog.jsonl
+scrape.log
 .DS_Store
 README_files
 README.html

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -126,6 +126,17 @@ def get_table(
     )
     df.columns = [column_text_replace(c) for c in df.columns]
 
+    # Upstream uses different locale-column headers per areatype: "County"
+    # for by-county, "State" for by-state. Normalize to `reported_locale`
+    # here so downstream code (and the later locale_type derivation) doesn't
+    # KeyError on whichever flavor it didn't expect. Pre-fix, the by-state
+    # branch raised and the master_table try/except swallowed every state
+    # combo silently — see #11 follow-up.
+    if "county" in df.columns:
+        df = df.rename(columns={"county": "reported_locale"})
+    elif "state" in df.columns:
+        df = df.rename(columns={"state": "reported_locale"})
+
     def get_text_from_select_id(group, id):
         return select_opts[group][id]
 
@@ -136,16 +147,37 @@ def get_table(
     df["cancer"] = get_text_from_select_id("cancer", cancer)
     df["areatype"] = get_text_from_select_id("areatype", areatype)
     df["age"] = get_text_from_select_id("age", age)
+    df.loc[df["fips"].isna(), "fips"] = ""
     df["state_fips"] = df["fips"].str[:2]
     if _type == "incd":
         df["measurement"] = "incidence"
     else:
         df["measurement"] = "mortality"
+    # locale_type derivation. The request `areatype` tells us which view of
+    # the data the row came from, which is the source of truth for whether a
+    # row is state-level or county-level. FIPS shape alone would mis-label
+    # corner cases — DC (11001), Puerto Rico (72001), and the Alaska
+    # aggregate (02900) come back from the by-state view with 5-char FIPS
+    # that don't end in 000. So:
+    #   - any row whose FIPS starts with "00" is the national aggregate;
+    #   - otherwise the request areatype dictates state vs county.
+    # For county-areatype runs, FIPS-shape still distinguishes the embedded
+    # state-aggregate row (e.g. 06000) when one shows up.
     df["locale_type"] = "other"
-    df.loc[df["fips"].isna(), "fips"] = ""
-    df.loc[df["fips"].str.endswith("000"), "locale_type"] = "state"
-    df.loc[df["fips"].str.startswith("00"), "locale_type"] = "national"
-    df.loc[df["county"].str.contains("County"), "locale_type"] = "county"
+    is_5char = df["fips"].str.len().eq(5)
+    is_national = is_5char & df["fips"].str.startswith("00")
+    df.loc[is_national, "locale_type"] = "national"
+    if areatype == "state":
+        df.loc[is_5char & ~is_national, "locale_type"] = "state"
+    elif areatype == "county":
+        df.loc[
+            is_5char & ~is_national & df["fips"].str.endswith("000"),
+            "locale_type",
+        ] = "state"
+        df.loc[
+            is_5char & ~is_national & ~df["fips"].str.endswith("000"),
+            "locale_type",
+        ] = "county"
     df["_extracted_at"] = pd.Timestamp.now().isoformat()
     # to allow for easy linkout to the website
     df["url"] = url.replace("&output=1", "")
@@ -244,14 +276,16 @@ def master_table(
             logger.debug("Caught an exception, but ignoring it")
             logger.debug(e)
     df = pd.concat(dflist)
-    df[["locale", "state"]] = df.county.str.replace(
+    # Split "Galax City, Virginia(2)" → ("Galax City", "Virginia") for county
+    # rows. State-level rows have no comma (e.g. "California") and split into
+    # ("California", None), which is the right shape.
+    df[["locale", "state"]] = df.reported_locale.str.replace(
         r"\(.*\)", "", regex=True
     ).str.split(", ", expand=True, n=1)
     if _type == "incd":
         column_translation = {
             "lower_95pct_confidence_interval_1": "lower_ci_trend_in_rate",
             "upper_95pct_confidence_interval_1": "upper_ci_trend_in_rate",
-            "county": "reported_locale",
             "age_adjusted_incidence_raterate_note___cases_per_100_000": "age_adjusted_rate_per_100_000",
             "ci_rankrank_note": "ci_rank",
             "lower_ci_ci_rank": "lower_ci_rank",
@@ -262,7 +296,6 @@ def master_table(
         }
     if _type == "death":
         column_translation = {
-            "county": "reported_locale",
             "age_adjusted_death_raterate_note___deaths_per_100_000": "age_adjusted_rate_per_100_000",
             "ci_rankrank_note": "ci_rank",
             "lower_ci_ci_rank": "lower_ci_rank",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -100,7 +100,7 @@ def test_master_table_uses_combo_iterator_and_calls_on_success(tmp_path):
 
     def fake_get_table(**kwargs):
         seen_combos.append(kwargs)
-        return pd.DataFrame({"county": ["X, CO"], "fips": ["08001"]})
+        return pd.DataFrame({"reported_locale": ["X, CO"], "fips": ["08001"]})
 
     combos = [
         {"cancer": "001", "age": "001", "sex": "0", "race": "00", "stage": "999", "areatype": "county"},

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from scps import scraper
@@ -162,9 +163,11 @@ def test_master_table_iterates_areatypes():
         import pandas as pd
         # master_table splits `county` on ", " into (locale, state) — use a
         # comma-bearing string so the split produces two columns.
+        # master_table now expects `reported_locale` (get_table renames the
+        # raw "county"/"state" column to this); replicate that here.
         return pd.DataFrame(
             {
-                "county": ["Somewhere County, CO"],
+                "reported_locale": ["Somewhere County, CO"],
                 "fips": ["08001"],
                 "age_adjusted_incidence_raterate_note___cases_per_100_000": [1.0],
             }
@@ -195,9 +198,11 @@ def test_master_table_default_areatype_is_county_only():
     def fake_get_table(**kwargs):
         captured_areatypes.append(kwargs.get("areatype"))
         import pandas as pd
+        # master_table now expects `reported_locale` (get_table renames the
+        # raw "county"/"state" column to this); replicate that here.
         return pd.DataFrame(
             {
-                "county": ["Somewhere County, CO"],
+                "reported_locale": ["Somewhere County, CO"],
                 "fips": ["08001"],
                 "age_adjusted_incidence_raterate_note___cases_per_100_000": [1.0],
             }
@@ -218,6 +223,87 @@ def test_master_table_default_areatype_is_county_only():
         scraper.master_table()
 
     assert set(captured_areatypes) == {"county"}
+
+
+def test_get_table_handles_state_areatype_response():
+    """By-state responses have `State`+`FIPS` columns, not `County`+`FIPS`.
+
+    Regression for the bug where state-areatype combos silently failed because
+    df["county"] raised KeyError and master_table swallowed it.
+    """
+    state_csv = pd.DataFrame(
+        {
+            "state": [
+                "California",
+                "Texas",
+                "District of Columbia",  # 11001 — 5-char non-000 FIPS, still state
+                "Alaska",                # 02900 — aggregated registry, special FIPS
+            ],
+            "fips": ["06000", "48000", "11001", "02900"],
+            "age_adjusted_incidence_raterate_note___cases_per_100_000": [
+                400.0, 410.0, 420.0, 430.0,
+            ],
+            "lower_95pct_confidence_interval": [395.0, 405.0, 415.0, 425.0],
+            "upper_95pct_confidence_interval": [405.0, 415.0, 425.0, 435.0],
+            "ci_rankrank_note": ["1", "2", "3", "4"],
+            "lower_ci_ci_rank": [1, 2, 3, 4],
+            "upper_ci_ci_rank": [3, 4, 5, 6],
+            "average_annual_count": [100000, 90000, 5000, 3000],
+            "recent_trend": ["stable"] * 4,
+            "recent_5_year_trend_trend_note_in_incidence_rates": [0.1, 0.2, 0.0, -0.1],
+            "lower_95pct_confidence_interval_1": [0.0, 0.1, -0.1, -0.2],
+            "upper_95pct_confidence_interval_1": [0.2, 0.3, 0.1, 0.0],
+        }
+    )
+
+    with patch("pandas.read_csv", return_value=state_csv):
+        df = scraper.get_table(areatype="state")
+
+    assert "reported_locale" in df.columns
+    assert "county" not in df.columns
+    assert "state" not in df.columns  # the source column got renamed
+    # Every row in the by-state view classifies as "state", including the
+    # 5-char-non-000 FIPS rows for DC and the Alaska aggregate.
+    assert (df["locale_type"] == "state").all()
+
+
+def test_get_table_locale_type_from_fips_shape():
+    """For by-county runs, classification uses FIPS shape — not locale-string.
+
+    Regression for county-equivalents (parishes, boroughs, independent cities)
+    that don't have the word "County" in their name. Also verifies that a
+    state-aggregate row (FIPS XX000) embedded in a county-view response is
+    labeled "state".
+    """
+    mixed_csv = pd.DataFrame(
+        {
+            "county": [
+                "United States",                  # 00000 → national
+                "California",                     # 06000 → state aggregate row
+                "Iberville Parish, Louisiana",    # 22047 → county-equivalent
+                "Lake and Peninsula Borough, AK", # 02164 → county-equivalent
+                "Galax City, Virginia",           # 51640 → county-equivalent (city)
+                "Plain County, Anywhere",         # 12345 → traditional county
+            ],
+            "fips": ["00000", "06000", "22047", "02164", "51640", "12345"],
+            "age_adjusted_incidence_raterate_note___cases_per_100_000": [
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+            ],
+        }
+    )
+
+    with patch("pandas.read_csv", return_value=mixed_csv):
+        df = scraper.get_table(areatype="county")
+
+    by_fips = dict(zip(df["fips"], df["locale_type"]))
+    assert by_fips == {
+        "00000": "national",
+        "06000": "state",
+        "22047": "county",
+        "02164": "county",
+        "51640": "county",
+        "12345": "county",
+    }
 
 
 def test_get_table_death_url():


### PR DESCRIPTION
Surfaced by the first local discovery run after #14 merged. Two related bugs in `scps.scraper.get_table`:

## Bug 1 — every by-state combo was silently dropped

The state-cancer-profiles by-state endpoint returns a `State` column header (not `County`). After `column_text_replace`, `get_table` reached `df["county"].str.contains("County")`, which raised `KeyError`. `master_table` catches all exceptions per combo, so this looked like **3,672 silent failures**:

```
$ jq -r 'select(.endpoint=="incidence") | .areatype' scrape_catalog.jsonl | sort | uniq -c
3546 county
# ← no `state` entries, despite iterating areatypes=("county","state")
```

The output CSV reflected the loss — incidence had 0 rows with `locale_type == "state"`.

## Bug 2 — county-equivalents fell into `other`

`locale_type` was set via `.str.contains("County")` on the locale name. That misses:
- Louisiana parishes (`Iberville Parish, Louisiana`)
- Alaska boroughs / census areas (`Lake and Peninsula Borough, Alaska`)
- Virginia independent cities (`Galax City, Virginia`)
- DC, Puerto Rico, etc.

55,197 incidence rows landed in `other` because of this.

## Fix

1. `get_table` normalizes the locale column (`county` or `state`) to `reported_locale` at parse time. master_table's `column_translation` loses its redundant `county` → `reported_locale` entries.
2. `locale_type` derivation now uses the request `areatype` plus FIPS shape, not the locale string:
   - FIPS starting with `00` → `national`
   - by-state view → all non-national rows are `state` (correctly handles 5-char-non-000 FIPS for DC `11001`, Puerto Rico `72001`, Alaska aggregate `02900`)
   - by-county view → FIPS ending in `000` → `state` (e.g. embedded `06000` California aggregate row), otherwise `county`

The `areatype` request context is the source of truth because pure FIPS-shape would mislabel the by-state edge cases.

## Tests

- `test_get_table_handles_state_areatype_response` — regression for bug 1, with state-areatype mock data including DC and Alaska edge-case FIPS
- `test_get_table_locale_type_from_fips_shape` — regression for bug 2, covers parishes / boroughs / independent cities plus an embedded state-aggregate row
- Existing `test_master_table_*` mocks updated to return `reported_locale` (matching post-fix output)
- **59 passing** (was 57)

## Verified against live site

```
by-state areatype:  53 rows → 52 state + 1 national   (was: 0 state rows)
by-county areatype: 3030 rows → 3029 county + 1 national
```

## Follow-up

The on-disk `scrape_catalog.jsonl` from the local discovery run only has county-areatype entries for incidence/mortality. After this PR lands, the next `--refresh-catalog` run (or just deleting the catalog) will pick up the ~3k+ state-areatype combos per endpoint and the released CSVs will include both areatypes.

## Test plan

- [x] `uv run pytest -q` → 59 passed
- [x] Live `get_table(areatype="state")` returns 53 rows, all classified `state`/`national`
- [x] Live `get_table(areatype="county")` returns 3030 rows, all classified `county`/`national`
- [ ] CI green on this PR