### PR TITLE
M2: manifest + harmonized view; M3: Zenodo deposit machinery

### DIFF
--- a/data/crosswalks.json
+++ b/data/crosswalks.json
@@ -1,0 +1,21 @@
+{
+  "comment": "Harmonization decisions as data (SPEC M2). race_canonical maps a cleaned topic-local race label to the incidence/mortality vocabulary ONLY where the populations are semantically identical (formatting, escaping, or typo differences). Labels absent here denote populations with no exact equivalent (e.g. demographics 'Asian Non-Hispanic' is not incidence 'Asian / Pacific Islander (Non-Hispanic)') and keep race_canonical null.",
+  "column_renames": {
+    "2023_rural_urban_continuum_codesrural_urban_note": "rural_urban"
+  },
+  "race_label_fixes": {
+    "White (includes Hispanic": "White (includes Hispanic)"
+  },
+  "race_canonical": {
+    "All Races (includes Hispanic)": "All Races (includes Hispanic)",
+    "Hispanic (any race)": "Hispanic (any race)",
+    "White (Non-Hispanic)": "White (Non-Hispanic)",
+    "White Non-Hispanic": "White (Non-Hispanic)",
+    "Black (Non-Hispanic)": "Black (Non-Hispanic)",
+    "Black Non-Hispanic": "Black (Non-Hispanic)",
+    "Amer. Indian / AK Native (Non-Hispanic)": "Amer. Indian / AK Native (Non-Hispanic)",
+    "American Indian/Alaska Native Non-Hispanic": "Amer. Indian / AK Native (Non-Hispanic)",
+    "Asian / Pacific Islander (Non-Hispanic)": "Asian / Pacific Islander (Non-Hispanic)",
+    "Asian / Pacifice Islander (Non-Hispanic)": "Asian / Pacific Islander (Non-Hispanic)"
+  }
+}

--- a/data/vintages.json
+++ b/data/vintages.json
@@ -1,0 +1,76 @@
+{
+ "method": "content sha256 after dropping _extracted_at; see docs/releases.md",
+ "vintages": {
+  "V1": {
+   "releases": [
+    "2024-08-02-1"
+   ],
+   "first_capture": "2024-08-02",
+   "best_capture": "2024-08-02-1",
+   "defective_releases": [],
+   "content_sha256": {
+    "incidence": [
+     "95bb771c674254becb61c635745bf34b73dcd9cd58ae3731d9ea8c5a040060b2"
+    ],
+    "mortality": [
+     "1f40af102eb84043a0eab51b77c1a95c277012864308b95f37f729ac1488496e"
+    ]
+   }
+  },
+  "V2": {
+   "releases": [
+    "2025-02-10",
+    "2025-03-01",
+    "2025-04-01",
+    "2025-05-01",
+    "2025-06-01",
+    "2025-07-01",
+    "2025-08-01",
+    "2025-09-01",
+    "2025-10-01",
+    "2025-11-01",
+    "2025-12-01",
+    "2026-01-01",
+    "2026-02-01"
+   ],
+   "first_capture": "2025-02-10",
+   "best_capture": "2026-02-01",
+   "defective_releases": [
+    "2025-05-01",
+    "2025-09-01"
+   ],
+   "content_sha256": {
+    "incidence": [
+     "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+     "99a237b478d8540b0ccbbaecc09477323f877025b216f152396ec9e61293ff00"
+    ],
+    "mortality": [
+     "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931",
+     "342cb495c3f13d88617bf4b68ad84d50c9a2a812eba493d03aa59169e55ce274"
+    ]
+   }
+  },
+  "V3": {
+   "releases": [
+    "2026-04-01",
+    "2026-05-01",
+    "2026-05-27",
+    "2026-05-28",
+    "2026-06-01"
+   ],
+   "first_capture": "2026-04-01",
+   "best_capture": "2026-06-01",
+   "defective_releases": [],
+   "content_sha256": {
+    "incidence": [
+     "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32",
+     "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa"
+    ],
+    "mortality": [
+     "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398",
+     "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c"
+    ]
+   }
+  }
+ }
+}

--- a/manifests/2024-08-02-1.json
+++ b/manifests/2024-08-02-1.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2024-08-02-1",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "77bd1f5eef92f039ff7c63adaba3388c16e5b8179aa9bb3530134f66550a28d9",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "ac6f22889d63b3c371d830df607cdf265e575aa1f0e1ab160b323bc10a36c867",
+   "bytes": 33329612,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 934287,
+   "content_sha256": "95bb771c674254becb61c635745bf34b73dcd9cd58ae3731d9ea8c5a040060b2"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "ecd44edad0f747dac851982110b0c4527eace923b0c6ea26241523e21242b7df",
+   "bytes": 27002626,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 774770,
+   "content_sha256": "1f40af102eb84043a0eab51b77c1a95c277012864308b95f37f729ac1488496e"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "95bb771c674254becb61c635745bf34b73dcd9cd58ae3731d9ea8c5a040060b2",
+  "mortality": "1f40af102eb84043a0eab51b77c1a95c277012864308b95f37f729ac1488496e"
+ }
+}

--- a/manifests/2025-02-10.json
+++ b/manifests/2025-02-10.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-02-10",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "d32fd9f7835b4d4730655380f5dc71e016334a23ec4661fcc5dbce5da3a58269",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "a0bc80b3a8f1008ece5d7dd0d81043747c49081eaaa3a194c26bde017e0d8c89",
+   "bytes": 34018179,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "1ced1bb5b17815339149ea65cd3784c390f907068924a5b17ae78d72fb1f287b",
+   "bytes": 27681568,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-03-01.json
+++ b/manifests/2025-03-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-03-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "5ca4729f77f5516e024ca61735fa0d0d0b47d4ea9b1a8db89ed3a14ca41f5718",
+   "bytes": 34023975,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "e6a68ac4dc97c70d6bff4dd2dd63c5964f53063cd7f362fd2517f7b69995defa",
+   "bytes": 27686533,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-04-01.json
+++ b/manifests/2025-04-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-04-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "de2e34d5ce0492d088a7f4e564d40f1b8e1686f4a2b68b6b66920fd95f3c142f",
+   "bytes": 34019146,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "3731740d225efabacf908e1fce27bb2a2363da38f5eb4c7babd4c605cf0d8b45",
+   "bytes": 27682122,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-05-01.json
+++ b/manifests/2025-05-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-05-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "7c960e49b7afd84a5daed19bd527731ba3dd38f2f704538fc5b9adae6294ad67",
+   "bytes": 33978884,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1013440,
+   "content_sha256": "99a237b478d8540b0ccbbaecc09477323f877025b216f152396ec9e61293ff00"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "eaeb0627fb3cf7ccba03b82f82c0db9ccca72f70b1f554af9f26b3edd2a170dd",
+   "bytes": 27681559,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "99a237b478d8540b0ccbbaecc09477323f877025b216f152396ec9e61293ff00",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-06-01.json
+++ b/manifests/2025-06-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-06-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "c2127e6e007eb07237e2dc6bcb74dbf53a2c541103f909aefbf06d9d2e2d08be",
+   "bytes": 34019904,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "52229151c84056f68229474e38544aa3752ef74490bea6b14560be53e63dbb87",
+   "bytes": 27682817,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-07-01.json
+++ b/manifests/2025-07-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-07-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "29a4580923d348868b04b212f3b06e7eff3530c6f85cc12f9e1d7c549880b1a3",
+   "bytes": 34019856,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "e824ac143f30bf0501863d6c36be34d125c6b8b1d2509b564383492ef82e150a",
+   "bytes": 27682802,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-08-01.json
+++ b/manifests/2025-08-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-08-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "23b9dda506583f56cd0f444ad02cb5389f889a2451c5bcc8c27d1dacee521052",
+   "bytes": 34017586,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "9b380d49950c4a080c8fcda329b8eebc5bfff13e4bd70b6bfe15808b448eb86e",
+   "bytes": 27681245,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-09-01.json
+++ b/manifests/2025-09-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-09-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "da34ce535b91f03f417e22c9b7209da31b8fb9b0a131e1fc3250588133f3ce26",
+   "bytes": 34018734,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "ac6d4ae250145e5e9e1187abe54354748556a4b8c167328d5f32e324eb30f543",
+   "bytes": 27681834,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782628,
+   "content_sha256": "342cb495c3f13d88617bf4b68ad84d50c9a2a812eba493d03aa59169e55ce274"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "342cb495c3f13d88617bf4b68ad84d50c9a2a812eba493d03aa59169e55ce274"
+ }
+}

--- a/manifests/2025-10-01.json
+++ b/manifests/2025-10-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-10-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "a671b7116ee77c671327d417f8d084333bfe4464d6b7a56464f0ee6028a84258",
+   "bytes": 34018465,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "c6f7c783a01f6f6036018756732053df53d43941564431e8f64cd556c728f7f3",
+   "bytes": 27681815,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-11-01.json
+++ b/manifests/2025-11-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-11-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "a4143e8e8211d7697eb547c45883ecc1f8a4ba0dd0a40c2fe50adb505412faa9",
+   "bytes": 34020886,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "159828ac05eb56947dc4b40de24366a552314f1d1100d74f29418281219333a7",
+   "bytes": 27683610,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2025-12-01.json
+++ b/manifests/2025-12-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2025-12-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "cd8aa59400e9551dee01c3502f305dc27d8523a534d0b5c50cfe5a35b5701119",
+   "bytes": 34020095,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "e38e549453e6e1b7a5e0791cfc7d28ad171e5aa5ebd1a0605058611acea435d2",
+   "bytes": 27683009,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2026-01-01.json
+++ b/manifests/2026-01-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2026-01-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "7fe1692a9e515950fe08a5635002e7cacc45697f0557b907f5311fc8395dcbec",
+   "bytes": 34019884,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "f8a6e0e76584d2e13b0f8d6802ae11b869eb861399b4c39f125f36a4db08ed71",
+   "bytes": 27682698,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2026-02-01.json
+++ b/manifests/2026-02-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2026-02-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "47c5024c509d7640436835172985cc141cb902dd8686e574a3d6aca790607b65",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "3e4e91c629bebec0a062ec49e60437e6d8940b5803abac2b8efdf663bc9ac684",
+   "bytes": 2295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "4fbfdf7e24642b400d679526d70f0d5d3f92d5ca7a75750e4dddc557976d641d",
+   "bytes": 34020664,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1014762,
+   "content_sha256": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "a0945b05edb470c6438b70eb4eb1ba71b69a6162e6a81a4dff3061bc7f029cc4",
+   "bytes": 27683312,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 782632,
+   "content_sha256": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "2ae50c264b32f2824c74fe7cdd338fcf14aa745835f552eb14d4b3d1a9f5548f",
+  "mortality": "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931"
+ }
+}

--- a/manifests/2026-04-01.json
+++ b/manifests/2026-04-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2026-04-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "1d9011de45ed2726dc7b43fa6638b1eb736aaee13647b41be3adb31169234a43",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "d321cf7ef3612c9f30172cc66b7f7387adb54f3263f874819da12346830affe4",
+   "bytes": 45467922,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1354812,
+   "content_sha256": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "298aa665e4b7351db4eadc2a6295649d2f5523ca82f4f5610c30fd2380743e1e",
+   "bytes": 33489500,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 928958,
+   "content_sha256": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32",
+  "mortality": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+ }
+}

--- a/manifests/2026-05-01.json
+++ b/manifests/2026-05-01.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2026-05-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "1d9011de45ed2726dc7b43fa6638b1eb736aaee13647b41be3adb31169234a43",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "caf734dbc1aa012efc4edc1bab7e71d69fab5135d773d0e7430cb5542cb22abc",
+   "bytes": 45466259,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1354812,
+   "content_sha256": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "510b06a9ee6e41d716a940e0390fb3ef0a292a97a5ce18ea4769d7b033718608",
+   "bytes": 33487098,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 928958,
+   "content_sha256": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32",
+  "mortality": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+ }
+}

--- a/manifests/2026-05-27.json
+++ b/manifests/2026-05-27.json
@@ -1,0 +1,37 @@
+{
+ "tag": "2026-05-27",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "717240ffc1d9fdb98346f9c60fa933d11c3350c29d3d4f502b669eb96153ee81",
+   "bytes": 41
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "0dd3894bc88e3a0a262d834bff53a786b3b8811a306e1b2e3b3907dd10ab8d22",
+   "bytes": 45466897,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1354812,
+   "content_sha256": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "bfab5c125aef979ad7e2f8b71818fd196bbab296bd03fffd965f44f4ccb33c40",
+   "bytes": 33487297,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 928958,
+   "content_sha256": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+  }
+ ],
+ "content_hashes": {
+  "incidence": "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32",
+  "mortality": "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398"
+ }
+}

--- a/manifests/2026-05-28.json
+++ b/manifests/2026-05-28.json
@@ -1,0 +1,62 @@
+{
+ "tag": "2026-05-28",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "55a6c238094d391ee658c428f42dc3031a20a80de5c8f577ae67347f5c8d91a8",
+   "bytes": 41
+  },
+  {
+   "filename": "scrape_catalog.jsonl",
+   "sha256": "d812dfae5c4c1870d32fdd2abe6d98fda0d8b3436c53cb2c0563b005eb793c09",
+   "bytes": 3536069
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_demographics.csv.gz",
+   "sha256": "18d57bd88a7245c0cbc3466d0befbdcb7ef7f8b882514abb660de5327ecb9e51",
+   "bytes": 61867697,
+   "format": "csv.gz",
+   "topic": "demographics",
+   "rows": 3310984,
+   "content_sha256": "93305466c13a4d04aa4a0aedf9f11529c6b8a63ef51c6aa8b5a7d3c69e44c63b"
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "121c3456399e29db51257d8e683e03f1e7f4b4b2b9c47665d5ae20b57b941bda",
+   "bytes": 48922320,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1476853,
+   "content_sha256": "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "21a75dcd19eb3e8c41b10f8817096e22bc5a0ca3445a42bbfc3f6e04d4329c77",
+   "bytes": 35505017,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 1034042,
+   "content_sha256": "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c"
+  },
+  {
+   "filename": "state_cancer_profiles_risk.csv.gz",
+   "sha256": "4c6bc8fa70a0d1e54269875f7ded87d9de45c781d08628ff61d44dec02a6f910",
+   "bytes": 1460061,
+   "format": "csv.gz",
+   "topic": "risk",
+   "rows": 83429,
+   "content_sha256": "663798d89d3339e0a21aae30b1addde62bc8fdd03308f310d458bc08bd32569b"
+  }
+ ],
+ "content_hashes": {
+  "demographics": "93305466c13a4d04aa4a0aedf9f11529c6b8a63ef51c6aa8b5a7d3c69e44c63b",
+  "incidence": "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa",
+  "mortality": "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c",
+  "risk": "663798d89d3339e0a21aae30b1addde62bc8fdd03308f310d458bc08bd32569b"
+ }
+}

--- a/manifests/2026-06-01.json
+++ b/manifests/2026-06-01.json
@@ -1,0 +1,62 @@
+{
+ "tag": "2026-06-01",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "c618f208070e570124494c0934967a8654365b7c943950c281beeccd6d4353b5",
+   "bytes": 41
+  },
+  {
+   "filename": "scrape_catalog.jsonl",
+   "sha256": "182b65de5d61920f46159a595296c7517854e9f7d33fae3357ed6bee3c850e5d",
+   "bytes": 3536069
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_demographics.csv.gz",
+   "sha256": "fc21126232b7dca4ff22959aa0ceeceea269ddf22108d33745935da002e8983c",
+   "bytes": 61867234,
+   "format": "csv.gz",
+   "topic": "demographics",
+   "rows": 3310984,
+   "content_sha256": "6a8dfedb0c077c0b5e8f4f72e336eebaa4749134d35287db21e093df5062630b"
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "ec6bc04db4e5b43273c9735f395d8eba47576fcfe0978cad0214f409c7008491",
+   "bytes": 48923235,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 1476853,
+   "content_sha256": "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "8c031c97289b76c49d6239fabb1d23fa8016954501183eb2da27ada6fee9a2dd",
+   "bytes": 35507557,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 1034042,
+   "content_sha256": "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c"
+  },
+  {
+   "filename": "state_cancer_profiles_risk.csv.gz",
+   "sha256": "2fcf62382b26d2ec89ac3b111c725189b5ee1cc0abf418c13360e156b3207747",
+   "bytes": 1460080,
+   "format": "csv.gz",
+   "topic": "risk",
+   "rows": 83429,
+   "content_sha256": "36fc0cc9a8a9867168b31e8c74a49e34bcf2a24588a5e9ccb31bb4e8a131170d"
+  }
+ ],
+ "content_hashes": {
+  "demographics": "6a8dfedb0c077c0b5e8f4f72e336eebaa4749134d35287db21e093df5062630b",
+  "incidence": "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa",
+  "mortality": "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c",
+  "risk": "36fc0cc9a8a9867168b31e8c74a49e34bcf2a24588a5e9ccb31bb4e8a131170d"
+ }
+}

--- a/scps/manifest.py
+++ b/scps/manifest.py
@@ -1,0 +1,119 @@
+"""Per-release provenance manifest: sha256, sizes, row counts, vintage.
+
+A *vintage* is a distinct set of upstream SCP estimates. Historical release
+artifacts carry no upstream vintage string (the pre-#39 scraper discarded
+the report notes), so vintage identity is derived from content: two releases
+whose files are identical after dropping the scrape-time ``_extracted_at``
+column captured the same upstream data. See ``docs/releases.md`` for the
+audit that established the method and the V1-V3 grouping.
+
+The release-tag → vintage mapping is data, not code: ``data/vintages.json``.
+``assign_vintage`` extends it for a new release by comparing content hashes
+against the latest known vintage.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pandas as pd
+
+TOPICS = ("incidence", "mortality", "risk", "demographics")
+
+# Topics whose content hash defines vintage identity. risk/demographics only
+# exist from 2026-05-28 and their arrival was a scraper scope change, not a
+# vintage change (docs/releases.md §1.2), so they don't participate.
+VINTAGE_TOPICS = ("incidence", "mortality")
+
+_CREATED_RE = re.compile(
+    r"Created by statecancerprofiles\.cancer\.gov on ([0-9/]+)"
+)
+_SUBMISSION_RE = re.compile(r"[Bb]ased on the (\d{4}) submission")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def content_hash(csv_gz: Path) -> tuple[str, int]:
+    """Return (sha256 of content minus ``_extracted_at``, row count).
+
+    The scrape timestamp is the only column that varies between captures of
+    the same upstream data; hashing without it makes byte-level vintage
+    comparison possible.
+    """
+    df = pd.read_csv(csv_gz, dtype=str, low_memory=False)
+    df = df.drop(columns=["_extracted_at"], errors="ignore")
+    payload = df.to_csv(index=False).encode()
+    return hashlib.sha256(payload).hexdigest(), len(df)
+
+
+def extract_notes_fields(notes_text: str) -> dict:
+    """Pull provenance fields from a ``notes_<endpoint>.txt`` block.
+
+    Only available for releases made after PR #39; historical releases have
+    no notes and their manifests carry ``notes: null``.
+    """
+    created = _CREATED_RE.search(notes_text)
+    submissions = sorted(set(_SUBMISSION_RE.findall(notes_text)))
+    return {
+        "created_on": created.group(1) if created else None,
+        "submission_years": submissions,
+    }
+
+
+def build_manifest(release_dir: Path, tag: str) -> dict:
+    """Manifest for one release directory (downloaded GitHub release assets)."""
+    files = []
+    content_hashes: dict[str, str] = {}
+    for path in sorted(release_dir.iterdir()):
+        if not path.is_file():
+            continue
+        entry: dict = {
+            "filename": path.name,
+            "sha256": sha256_file(path),
+            "bytes": path.stat().st_size,
+        }
+        topic = next(
+            (t for t in TOPICS if path.name == f"state_cancer_profiles_{t}.csv.gz"),
+            None,
+        )
+        if topic:
+            chash, rows = content_hash(path)
+            entry.update(format="csv.gz", topic=topic, rows=rows, content_sha256=chash)
+            content_hashes[topic] = chash
+        elif path.suffix == ".parquet":
+            entry.update(format="parquet", rows=len(pd.read_parquet(path, columns=[])))
+        notes_match = re.fullmatch(r"notes_(\w+)\.txt", path.name)
+        if notes_match:
+            entry["notes"] = extract_notes_fields(path.read_text())
+        files.append(entry)
+    return {"tag": tag, "files": files, "content_hashes": content_hashes}
+
+
+def load_vintages(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def assign_vintage(manifest: dict, vintages: dict) -> tuple[str, bool]:
+    """Return (vintage_id, is_new) for a release manifest.
+
+    Same incidence+mortality content hashes as the latest vintage → that
+    vintage. Any difference → a new vintage id. Defective partial scrapes
+    can't reach this path anymore (the catalog regression oracle fails the
+    run first), so hash inequality means upstream really changed.
+    """
+    hashes = {t: manifest["content_hashes"].get(t) for t in VINTAGE_TOPICS}
+    for vid, vinfo in vintages["vintages"].items():
+        if all(hashes.get(t) in vinfo["content_sha256"].get(t, []) for t in VINTAGE_TOPICS):
+            return vid, False
+    latest = max(vintages["vintages"], key=lambda v: int(v.lstrip("V")))
+    return f"V{int(latest.lstrip('V')) + 1}", True

--- a/scps/normalize.py
+++ b/scps/normalize.py
@@ -1,0 +1,128 @@
+"""Derived harmonized view across vintages.
+
+This produces a NEW artifact from released files; original release bytes are
+never modified (root CLAUDE.md). Harmonization decisions are data
+(``data/crosswalks.json``), not code. The defects fixed here are the audit's
+list in ``docs/schema-drift.md``:
+
+- ``locale_type`` misclassification (derive from ``areatype`` + FIPS shape)
+- footnote-prose rows leaked into demographics/risk (null keys → dropped)
+- undecoded ``\\u00A0`` escapes and typos in race labels, plus a canonical
+  race mapping for cross-topic joins where populations are identical
+- the mangled RUCC column name
+- ``(1)``/``(2)``/``(7)`` source markers embedded in ``reported_locale``
+
+Accounting is strict: for every table, kept + dropped == original rows, and
+``harmonize`` raises if not.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pandas as pd
+
+CROSSWALKS_PATH = Path(__file__).resolve().parent.parent / "data" / "crosswalks.json"
+
+_SOURCE_NOTE_RE = re.compile(r"\((\d+)\)\s*$")
+_UNICODE_ESCAPE_RE = re.compile(r"\\u00a0", re.IGNORECASE)
+
+# Key column per topic: rows with a null key are leaked footnote prose,
+# not observations.
+_KEY_COLUMN = {
+    "incidence": "fips",
+    "mortality": "fips",
+    "risk": "fips",
+    "demographics": "area_code",
+}
+
+
+def load_crosswalks(path: Path = CROSSWALKS_PATH) -> dict:
+    return json.loads(path.read_text())
+
+
+def clean_race(series: pd.Series, crosswalks: dict) -> tuple[pd.Series, pd.Series]:
+    """Return (cleaned race label, canonical race label or <NA>)."""
+    cleaned = (
+        series.astype("string")
+        .str.replace(_UNICODE_ESCAPE_RE, " ", regex=True)
+        .str.replace("\u00a0", " ", regex=False)
+        .str.strip()
+        .replace(crosswalks.get("race_label_fixes", {}))
+    )
+    canonical = cleaned.map(crosswalks.get("race_canonical", {})).astype("string")
+    return cleaned, canonical
+
+
+def _fixed_locale_type(df: pd.DataFrame, key: str) -> pd.Series:
+    """Re-derive locale_type from areatype + FIPS shape.
+
+    The released ``locale_type`` bins 30-55k county-equivalents per release
+    as ``other`` (parishes, boroughs, independent cities, DC) in everything
+    before 2026-05-28. ``areatype`` is the request's source of truth.
+    """
+    code = df[key].astype("string").fillna("")
+    out = pd.Series("other", index=df.index, dtype="string")
+    is5 = code.str.len() == 5
+    national = is5 & code.str.startswith("00")
+    out[national] = "national"
+    if "areatype" in df.columns:
+        by_county = df["areatype"].astype("string").str.contains("County", na=False)
+        by_state = df["areatype"].astype("string").str.contains("State", na=False)
+        out[is5 & ~national & by_state] = "state"
+        out[is5 & ~national & by_county & code.str.endswith("000")] = "state"
+        out[is5 & ~national & by_county & ~code.str.endswith("000")] = "county"
+    return out
+
+
+def harmonize(
+    df: pd.DataFrame, topic: str, vintage: str, tag: str, crosswalks: dict | None = None
+) -> tuple[pd.DataFrame, int]:
+    """Harmonize one topic table. Returns (harmonized, dropped_row_count).
+
+    Raises ``AssertionError`` if kept + dropped != original (fail loudly,
+    per SPEC M2).
+    """
+    crosswalks = crosswalks or load_crosswalks()
+    original = len(df)
+    key = _KEY_COLUMN[topic]
+
+    df = df.rename(columns=crosswalks.get("column_renames", {}))
+
+    leaked = df[key].isna()
+    df = df[~leaked].copy()
+    dropped = int(leaked.sum())
+
+    if "race" in df.columns:
+        df["race"], df["race_canonical"] = clean_race(df["race"], crosswalks)
+
+    if "reported_locale" in df.columns:
+        df["source_note"] = (
+            df["reported_locale"].astype("string").str.extract(_SOURCE_NOTE_RE)[0]
+        )
+
+    df["locale_type"] = _fixed_locale_type(df, key)
+    df["vintage"] = vintage
+    df["release_tag"] = tag
+
+    assert len(df) + dropped == original, (
+        f"{topic}: {len(df)} kept + {dropped} dropped != {original} original"
+    )
+    return df, dropped
+
+
+def harmonize_release(
+    release_dir: Path, vintage: str, tag: str, crosswalks: dict | None = None
+) -> dict[str, tuple[pd.DataFrame, int]]:
+    """Harmonize every topic file present in a downloaded release directory."""
+    crosswalks = crosswalks or load_crosswalks()
+    out: dict[str, tuple[pd.DataFrame, int]] = {}
+    for topic in _KEY_COLUMN:
+        path = release_dir / f"state_cancer_profiles_{topic}.csv.gz"
+        if not path.exists():
+            continue
+        df = pd.read_csv(path, dtype=str, low_memory=False)
+        out[topic] = harmonize(df, topic, vintage, tag, crosswalks)
+    return out

--- a/scps/zenodo.py
+++ b/scps/zenodo.py
@@ -1,0 +1,224 @@
+"""Zenodo REST client and deposit planning for the vintage archive.
+
+Importable core so the logic is testable without a token; the runnable
+entry points are ``scripts/zenodo/backfill.py`` and
+``scripts/zenodo/publish_release.py``. API gotchas and the
+sandbox-first rule live in ``scripts/zenodo/CLAUDE.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger("scps.zenodo")
+
+PRODUCTION = "https://zenodo.org"
+SANDBOX = "https://sandbox.zenodo.org"
+
+# The data concept (docs/audit.md §3). The webhook-maintained software
+# concept 13174526 must never be written to by this code.
+PRODUCTION_CONCEPT_RECORD = "11098814"
+
+CREATORS = [{"name": "Davis, Sean", "orcid": "0000-0002-8991-6458"}]
+
+_RETRY_STATUSES = {429, 500, 502, 503, 504}
+
+
+def token_from_gsm(secret_name: str) -> str:
+    """Fetch a token from GCP Secret Manager via the gcloud CLI."""
+    return subprocess.run(
+        [
+            "gcloud", "secrets", "versions", "access", "latest",
+            f"--secret={secret_name}", "--project=cdsci-infra",
+        ],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+class ZenodoClient:
+    """Minimal deposit client. Sequential, with retry/backoff (rate limits
+    are modest — never upload concurrently)."""
+
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self._params = {"access_token": token}
+
+    def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        if url.startswith("/"):
+            url = self.base_url + url
+        params = {**self._params, **kwargs.pop("params", {})}
+        for attempt in range(6):
+            resp = httpx.request(
+                method, url, params=params, timeout=120.0, **kwargs
+            )
+            if resp.status_code not in _RETRY_STATUSES:
+                resp.raise_for_status()
+                return resp
+            wait = 2**attempt
+            logger.warning("%s %s -> %s; retrying in %ss", method, url, resp.status_code, wait)
+            time.sleep(wait)
+        resp.raise_for_status()
+        return resp
+
+    # -- read side -----------------------------------------------------
+    def concept_versions(self, concept_record_id: str) -> list[dict]:
+        """All published versions under a concept, oldest first."""
+        out: list[dict] = []
+        page = 1
+        while True:
+            resp = self._request(
+                "GET",
+                f"/api/records/{concept_record_id}/versions",
+                params={"page": page, "size": 25},  # 25 = unauthenticated page cap
+            ).json()
+            hits = resp.get("hits", {}).get("hits", [])
+            out.extend(hits)
+            total = resp.get("hits", {}).get("total", len(out))
+            if len(out) >= total or not hits:
+                break
+            page += 1
+        out.sort(key=lambda h: h.get("metadata", {}).get("publication_date", ""))
+        return out
+
+    # -- write side ----------------------------------------------------
+    def new_version_draft(self, record_id: str) -> dict:
+        """POST newversion, then return the draft deposition (work against
+        links.latest_draft, never the original id)."""
+        resp = self._request(
+            "POST", f"/api/deposit/depositions/{record_id}/actions/newversion"
+        ).json()
+        draft_url = resp["links"]["latest_draft"]
+        return self._request("GET", draft_url).json()
+
+    def clear_files(self, draft: dict) -> None:
+        """Files do not carry over usefully to a new version — remove all."""
+        for f in self._request("GET", draft["links"]["files"]).json():
+            self._request("DELETE", f["links"]["self"])
+
+    def upload_file(self, draft: dict, path: Path) -> None:
+        bucket = draft["links"]["bucket"]
+        with path.open("rb") as fh:
+            self._request("PUT", f"{bucket}/{path.name}", content=fh.read())
+
+    def set_metadata(self, draft: dict, metadata: dict) -> None:
+        self._request(
+            "PUT", draft["links"]["self"], json={"metadata": metadata}
+        )
+
+    def publish(self, draft: dict) -> dict:
+        return self._request("POST", draft["links"]["publish"]).json()
+
+
+# ---------------------------------------------------------------------------
+# Deposit planning — pure functions, unit-tested
+# ---------------------------------------------------------------------------
+
+@dataclass
+class VintageDeposit:
+    vintage_id: str
+    tags: list[str]
+    publication_date: str
+    best_capture: str
+    files: list[Path]
+
+
+def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-profile-scraper") -> dict:
+    """Deposit metadata for one vintage version.
+
+    ``related_identifiers`` carries every GitHub tag that captured the
+    vintage — this is also the idempotency key.
+    """
+    tag_urls = [f"https://github.com/{repo}/releases/tag/release-{t}" for t in dep.tags]
+    description = (
+        f"<p>State Cancer Profiles data extract — vintage {dep.vintage_id}. "
+        f"Complete national county- and state-level extract scraped from "
+        f"statecancerprofiles.cancer.gov, which offers no API, bulk download, "
+        f"or archive of prior estimates.</p>"
+        f"<p>This vintage was first captured on {dep.publication_date} and was "
+        f"served unchanged by the upstream site across {len(dep.tags)} scrape "
+        f"release(s): {', '.join(dep.tags)}. The deposited files are the most "
+        f"complete capture of the vintage (release {dep.best_capture}), which "
+        f"is not necessarily the first; the publication date reflects first "
+        f"capture. Vintage grouping method and release-level provenance: "
+        f"https://github.com/{repo}/blob/main/docs/releases.md</p>"
+    )
+    return {
+        "title": f"United States State Cancer Profiles data extract — vintage {dep.vintage_id}",
+        "upload_type": "dataset",
+        "publication_date": dep.publication_date,
+        "creators": CREATORS,
+        "license": "cc-by-4.0",
+        "description": description,
+        "keywords": ["cancer", "surveillance", "State Cancer Profiles", "SEER", "NPCR", "county", "incidence", "mortality"],
+        "related_identifiers": [
+            {"identifier": u, "relation": "isSupplementTo", "scheme": "url"}
+            for u in tag_urls
+        ],
+    }
+
+
+def deposited_tags(versions: list[dict]) -> set[str]:
+    """GitHub release tags already present across a concept's versions."""
+    tags: set[str] = set()
+    for v in versions:
+        for rel in v.get("metadata", {}).get("related_identifiers", []):
+            ident = rel.get("identifier", "")
+            if "/releases/tag/" in ident:
+                tags.add(ident.rsplit("/releases/tag/release-", 1)[-1])
+    return tags
+
+
+def plan_backfill(
+    vintages: dict, release_root: Path, existing_versions: list[dict]
+) -> list[VintageDeposit]:
+    """Deposits still needed, oldest first. Already-deposited vintages
+    (any of their tags present in existing metadata) are skipped —
+    re-running never duplicates."""
+    done = deposited_tags(existing_versions)
+    plan: list[VintageDeposit] = []
+    ordered = sorted(
+        vintages["vintages"].items(), key=lambda kv: kv[1]["first_capture"]
+    )
+    for vid, info in ordered:
+        if set(info["releases"]) & done:
+            logger.info("%s already deposited — skipping", vid)
+            continue
+        best_dir = release_root / info["best_capture"]
+        files = sorted(p for p in best_dir.iterdir() if p.is_file())
+        plan.append(
+            VintageDeposit(
+                vintage_id=vid,
+                tags=info["releases"],
+                publication_date=info["first_capture"],
+                best_capture=info["best_capture"],
+                files=files,
+            )
+        )
+    return plan
+
+
+def run_deposit(client: ZenodoClient, base_record_id: str, dep: VintageDeposit, dry_run: bool = False) -> str | None:
+    """Execute one vintage deposit as a new version of ``base_record_id``.
+    Returns the new record id (or None on dry run)."""
+    logger.info(
+        "%s: %d files from %s, publication_date=%s%s",
+        dep.vintage_id, len(dep.files), dep.best_capture, dep.publication_date,
+        " [dry-run]" if dry_run else "",
+    )
+    if dry_run:
+        return None
+    draft = client.new_version_draft(base_record_id)
+    client.clear_files(draft)
+    for path in dep.files:
+        logger.info("  upload %s (%d bytes)", path.name, path.stat().st_size)
+        client.upload_file(draft, path)
+    client.set_metadata(draft, vintage_metadata(dep))
+    published = client.publish(draft)
+    logger.info("  published %s -> %s", dep.vintage_id, published.get("doi"))
+    return str(published.get("id"))

--- a/scripts/zenodo/backfill.py
+++ b/scripts/zenodo/backfill.py
@@ -1,0 +1,77 @@
+"""One-time, idempotent Zenodo backfill: one version per vintage.
+
+Rehearse on sandbox FIRST (scripts/zenodo/CLAUDE.md). Sandbox is a separate
+instance, so the first sandbox run must create a throwaway base deposit
+there and pass its record id via --base-record.
+
+    # sandbox rehearsal (after creating a throwaway record there)
+    uv run python scripts/zenodo/backfill.py --sandbox \
+        --base-record <sandbox-record-id> --release-root /path/to/rel
+
+    # production, only after the sandbox output is reviewed
+    uv run python scripts/zenodo/backfill.py --release-root /path/to/rel
+
+``--release-root`` is a directory of downloaded release assets,
+one subdirectory per release tag (as produced by ``gh release download``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scps import zenodo  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--release-root", type=Path, required=True)
+    ap.add_argument("--vintages", type=Path, default=Path("data/vintages.json"))
+    ap.add_argument("--sandbox", action="store_true")
+    ap.add_argument("--base-record", default=None,
+                    help="Record id to branch versions from (required for --sandbox)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if args.sandbox:
+        base_url, secret = zenodo.SANDBOX, "cdsci-zenodo-sandbox-api-token"
+        if not args.base_record and not args.dry_run:
+            ap.error("--sandbox requires --base-record (create a throwaway deposit there first)")
+        base_record = args.base_record
+    else:
+        base_url, secret = zenodo.PRODUCTION, "cdsci-zenodo-api-token"
+        base_record = args.base_record or zenodo.PRODUCTION_CONCEPT_RECORD
+
+    if args.dry_run:
+        client = zenodo.ZenodoClient(base_url, "dry-run")
+        existing = []
+    else:
+        token = os.environ.get("ZENODO_TOKEN") or zenodo.token_from_gsm(secret)
+        client = zenodo.ZenodoClient(base_url, token)
+        existing = client.concept_versions(base_record)
+
+    vintages = json.loads(args.vintages.read_text())
+    plan = zenodo.plan_backfill(vintages, args.release_root, existing)
+    if not plan:
+        logging.info("Nothing to do — all vintages already deposited.")
+        return 0
+
+    # Each deposit becomes the base for the next version, keeping order.
+    current = base_record
+    for dep in plan:
+        new_id = zenodo.run_deposit(client, current, dep, dry_run=args.dry_run)
+        if new_id:
+            current = new_id
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zenodo/publish_release.py
+++ b/scripts/zenodo/publish_release.py
@@ -1,0 +1,98 @@
+"""Per-release Zenodo publisher, used by CI (SPEC M4).
+
+Same code path as the backfill — ``scps.zenodo`` — not a parallel
+implementation. Given a fresh scrape output directory and its release tag:
+build the manifest, assign a vintage against ``data/vintages.json``; if the
+vintage is new, publish a new version on the data concept and print the
+updated vintages.json for the caller to commit. If the vintage is already
+deposited, exit 0 without touching Zenodo.
+
+    uv run python scripts/zenodo/publish_release.py \
+        --release-dir . --tag 2026-09-01 [--sandbox --base-record ID] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scps import manifest as manifest_mod  # noqa: E402
+from scps import zenodo  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--release-dir", type=Path, required=True)
+    ap.add_argument("--tag", required=True)
+    ap.add_argument("--vintages", type=Path, default=Path("data/vintages.json"))
+    ap.add_argument("--sandbox", action="store_true")
+    ap.add_argument("--base-record", default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    m = manifest_mod.build_manifest(args.release_dir, args.tag)
+    (args.release_dir / "manifest.json").write_text(json.dumps(m, indent=1) + "\n")
+
+    vintages = manifest_mod.load_vintages(args.vintages)
+    vid, is_new = manifest_mod.assign_vintage(m, vintages)
+    if not is_new:
+        # Record the tag under its vintage so the mapping stays complete.
+        info = vintages["vintages"][vid]
+        if args.tag not in info["releases"]:
+            info["releases"].append(args.tag)
+            info["best_capture"] = args.tag
+            args.vintages.write_text(json.dumps(vintages, indent=1) + "\n")
+        logging.info("%s is vintage %s (already deposited) — nothing to publish.", args.tag, vid)
+        return 0
+
+    logging.info("%s is NEW vintage %s — publishing.", args.tag, vid)
+    vintages["vintages"][vid] = {
+        "releases": [args.tag],
+        "first_capture": args.tag,
+        "best_capture": args.tag,
+        "defective_releases": [],
+        "content_sha256": {t: [h] for t, h in m["content_hashes"].items()
+                           if t in manifest_mod.VINTAGE_TOPICS},
+    }
+
+    dep = zenodo.VintageDeposit(
+        vintage_id=vid,
+        tags=[args.tag],
+        publication_date=args.tag,
+        best_capture=args.tag,
+        files=sorted(p for p in args.release_dir.iterdir() if p.is_file()),
+    )
+
+    if args.sandbox:
+        base_url, secret = zenodo.SANDBOX, "cdsci-zenodo-sandbox-api-token"
+        base_record = args.base_record
+    else:
+        base_url, secret = zenodo.PRODUCTION, "cdsci-zenodo-api-token"
+        base_record = args.base_record or zenodo.PRODUCTION_CONCEPT_RECORD
+
+    if not args.dry_run:
+        token = os.environ.get("ZENODO_TOKEN") or zenodo.token_from_gsm(secret)
+        client = zenodo.ZenodoClient(base_url, token)
+        versions = client.concept_versions(base_record)
+        if args.tag in zenodo.deposited_tags(versions):
+            logging.info("Tag already in a deposited version — idempotent no-op.")
+            return 0
+        latest = versions[-1]["id"] if versions else base_record
+        zenodo.run_deposit(client, str(latest), dep, dry_run=False)
+    else:
+        zenodo.run_deposit(zenodo.ZenodoClient(zenodo.SANDBOX, "dry"), "0", dep, dry_run=True)
+
+    args.vintages.write_text(json.dumps(vintages, indent=1) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,97 @@
+"""Tests for scps.manifest — content hashing and vintage assignment."""
+
+import gzip
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from scps import manifest
+
+
+def _write_release(tmp_path: Path, extracted_at: str, rate: str = "1.0") -> Path:
+    rel = tmp_path / "rel"
+    rel.mkdir(parents=True, exist_ok=True)
+    for topic in ("incidence", "mortality"):
+        df = pd.DataFrame(
+            {
+                "fips": ["01001", "01003"],
+                "age_adjusted_rate_per_100_000": [rate, "2.0"],
+                "_extracted_at": [extracted_at, extracted_at],
+            }
+        )
+        df.to_csv(rel / f"state_cancer_profiles_{topic}.csv.gz", index=False, compression="gzip")
+    (rel / "gh_hash.txt").write_text("abc123\n")
+    return rel
+
+
+def test_content_hash_ignores_extracted_at(tmp_path):
+    a = _write_release(tmp_path / "a", "2026-01-01T00:00:00")
+    b = _write_release(tmp_path / "b", "2026-02-01T09:30:00")
+    ha, rows_a = manifest.content_hash(a / "state_cancer_profiles_incidence.csv.gz")
+    hb, rows_b = manifest.content_hash(b / "state_cancer_profiles_incidence.csv.gz")
+    assert ha == hb
+    assert rows_a == rows_b == 2
+
+
+def test_content_hash_differs_when_values_change(tmp_path):
+    a = _write_release(tmp_path / "a", "2026-01-01T00:00:00", rate="1.0")
+    b = _write_release(tmp_path / "b", "2026-01-01T00:00:00", rate="9.9")
+    ha, _ = manifest.content_hash(a / "state_cancer_profiles_incidence.csv.gz")
+    hb, _ = manifest.content_hash(b / "state_cancer_profiles_incidence.csv.gz")
+    assert ha != hb
+
+
+def test_build_manifest_covers_all_files(tmp_path):
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00")
+    m = manifest.build_manifest(rel, "test-tag")
+    assert m["tag"] == "test-tag"
+    names = {f["filename"] for f in m["files"]}
+    assert "state_cancer_profiles_incidence.csv.gz" in names
+    assert "gh_hash.txt" in names
+    assert set(m["content_hashes"]) == {"incidence", "mortality"}
+    inc = next(f for f in m["files"] if f["filename"].endswith("incidence.csv.gz"))
+    assert inc["rows"] == 2
+    assert inc["format"] == "csv.gz"
+    assert len(inc["sha256"]) == 64
+
+
+def test_extract_notes_fields():
+    notes = (
+        "Incidence Rate Report\n"
+        "Created by statecancerprofiles.cancer.gov on 08/23/2026 11:30 am.\n"
+        '"(1) Source: NPCR and SEER. Based on the 2024 submission."\n'
+        '"(7) Source: SEER November 2024 submission, based on the 2024 submission."\n'
+    )
+    fields = manifest.extract_notes_fields(notes)
+    assert fields["created_on"] == "08/23/2026"
+    assert fields["submission_years"] == ["2024"]
+
+
+def _vintages(hash_inc, hash_mort):
+    return {
+        "vintages": {
+            "V1": {
+                "releases": ["t1"],
+                "content_sha256": {"incidence": [hash_inc], "mortality": [hash_mort]},
+            }
+        }
+    }
+
+
+def test_assign_vintage_matches_existing(tmp_path):
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00")
+    m = manifest.build_manifest(rel, "t2")
+    vintages = _vintages(
+        m["content_hashes"]["incidence"], m["content_hashes"]["mortality"]
+    )
+    vid, is_new = manifest.assign_vintage(m, vintages)
+    assert (vid, is_new) == ("V1", False)
+
+
+def test_assign_vintage_detects_new(tmp_path):
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00", rate="7.7")
+    m = manifest.build_manifest(rel, "t2")
+    vintages = _vintages("deadbeef", "deadbeef")
+    vid, is_new = manifest.assign_vintage(m, vintages)
+    assert (vid, is_new) == ("V2", True)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,103 @@
+"""Tests for scps.normalize — the audit's defect list, one test each."""
+
+import pandas as pd
+import pytest
+
+from scps import normalize
+
+
+CROSSWALKS = normalize.load_crosswalks()
+
+
+def test_locale_type_rederived_from_areatype():
+    """Parishes/boroughs/cities binned `other` upstream become `county`."""
+    df = pd.DataFrame(
+        {
+            "fips": ["00000", "06000", "22047", "51640", "11001"],
+            "areatype": ["By County"] * 4 + ["By State"],
+            "reported_locale": ["US", "California", "Iberville Parish(2)", "Galax City(1)", "DC"],
+            "locale_type": ["national", "state", "other", "other", "state"],
+        }
+    )
+    out, dropped = normalize.harmonize(df, "incidence", "V2", "t", CROSSWALKS)
+    by_fips = dict(zip(out["fips"], out["locale_type"]))
+    assert by_fips == {
+        "00000": "national",
+        "06000": "state",
+        "22047": "county",
+        "51640": "county",
+        "11001": "state",
+    }
+    assert dropped == 0
+
+
+def test_leaked_note_rows_dropped_and_counted():
+    df = pd.DataFrame(
+        {
+            "area_code": ["00000", None, None],
+            "areatype": ["By County"] * 3,
+            "reported_locale": ["US", "Notes:", "Created by statecancerprofiles..."],
+        }
+    )
+    out, dropped = normalize.harmonize(df, "demographics", "V3", "t", CROSSWALKS)
+    assert len(out) == 1
+    assert dropped == 2
+
+
+def test_race_labels_cleaned_and_canonicalized():
+    df = pd.DataFrame(
+        {
+            "area_code": ["00000"] * 4,
+            "race": [
+                "\\u00A0\\u00A0\\u00A0White Non-Hispanic",
+                "White (includes Hispanic",
+                "Asian Non-Hispanic",
+                "All Races (includes Hispanic)",
+            ],
+        }
+    )
+    out, _ = normalize.harmonize(df, "demographics", "V3", "t", CROSSWALKS)
+    assert list(out["race"]) == [
+        "White Non-Hispanic",
+        "White (includes Hispanic)",
+        "Asian Non-Hispanic",
+        "All Races (includes Hispanic)",
+    ]
+    # Canonical only where populations are identical; Asian NH has no
+    # incidence equivalent (A/PI is a different population) and stays null.
+    assert out["race_canonical"].tolist()[0] == "White (Non-Hispanic)"
+    assert pd.isna(out["race_canonical"].tolist()[2])
+    assert out["race_canonical"].tolist()[3] == "All Races (includes Hispanic)"
+
+
+def test_risk_typo_canonicalized():
+    df = pd.DataFrame(
+        {
+            "fips": ["00000"],
+            "race": ["Asian / Pacifice Islander (Non-Hispanic)"],
+        }
+    )
+    out, _ = normalize.harmonize(df, "risk", "V3", "t", CROSSWALKS)
+    assert out["race_canonical"].iloc[0] == "Asian / Pacific Islander (Non-Hispanic)"
+
+
+def test_source_note_extracted_and_rucc_renamed():
+    df = pd.DataFrame(
+        {
+            "fips": ["53045", "53000"],
+            "areatype": ["By County"] * 2,
+            "reported_locale": ["Mason County(7)", "Washington(1)"],
+            "2023_rural_urban_continuum_codesrural_urban_note": ["Rural", None],
+        }
+    )
+    out, _ = normalize.harmonize(df, "incidence", "V3", "tag-x", CROSSWALKS)
+    assert list(out["source_note"]) == ["7", "1"]
+    assert "rural_urban" in out.columns
+    assert list(out["vintage"]) == ["V3", "V3"]
+    assert list(out["release_tag"]) == ["tag-x", "tag-x"]
+
+
+def test_accounting_is_strict():
+    df = pd.DataFrame({"fips": ["01001", None], "areatype": ["By County"] * 2})
+    out, dropped = normalize.harmonize(df, "incidence", "V1", "t", CROSSWALKS)
+    assert len(out) + dropped == 2

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -1,0 +1,95 @@
+"""Tests for scps.zenodo deposit planning — no network, no token."""
+
+from pathlib import Path
+
+from scps import zenodo
+
+
+def _vintages():
+    return {
+        "vintages": {
+            "V1": {
+                "releases": ["2024-08-02-1"],
+                "first_capture": "2024-08-02",
+                "best_capture": "2024-08-02-1",
+                "content_sha256": {"incidence": ["a"], "mortality": ["b"]},
+            },
+            "V2": {
+                "releases": ["2025-02-10", "2025-03-01"],
+                "first_capture": "2025-02-10",
+                "best_capture": "2025-03-01",
+                "content_sha256": {"incidence": ["c"], "mortality": ["d"]},
+            },
+        }
+    }
+
+
+def _release_root(tmp_path: Path) -> Path:
+    for tag in ("2024-08-02-1", "2025-03-01"):
+        d = tmp_path / tag
+        d.mkdir(exist_ok=True)
+        (d / "state_cancer_profiles_incidence.csv.gz").write_bytes(b"x")
+    return tmp_path
+
+
+def _version(tag: str) -> dict:
+    return {
+        "id": 1,
+        "metadata": {
+            "publication_date": "2024-08-02",
+            "related_identifiers": [
+                {
+                    "identifier": f"https://github.com/seandavi/state-cancer-profile-scraper/releases/tag/release-{tag}",
+                    "relation": "isSupplementTo",
+                }
+            ],
+        },
+    }
+
+
+def test_plan_backfill_oldest_first_and_uses_best_capture(tmp_path):
+    plan = zenodo.plan_backfill(_vintages(), _release_root(tmp_path), [])
+    assert [d.vintage_id for d in plan] == ["V1", "V2"]
+    v2 = plan[1]
+    assert v2.publication_date == "2025-02-10"      # first capture dates it
+    assert v2.best_capture == "2025-03-01"          # best capture supplies bytes
+    assert v2.files and v2.files[0].parent.name == "2025-03-01"
+
+
+def test_plan_backfill_is_idempotent(tmp_path):
+    existing = [_version("2024-08-02-1")]
+    plan = zenodo.plan_backfill(_vintages(), _release_root(tmp_path), existing)
+    assert [d.vintage_id for d in plan] == ["V2"]
+    # All tags deposited → empty plan.
+    plan2 = zenodo.plan_backfill(
+        _vintages(), _release_root(tmp_path), [_version("2024-08-02-1"), _version("2025-02-10")]
+    )
+    assert plan2 == []
+
+
+def test_vintage_metadata_carries_identity_and_tags(tmp_path):
+    plan = zenodo.plan_backfill(_vintages(), _release_root(tmp_path), [])
+    md = zenodo.vintage_metadata(plan[1])
+    assert md["publication_date"] == "2025-02-10"
+    assert md["license"] == "cc-by-4.0"
+    assert md["upload_type"] == "dataset"
+    idents = [r["identifier"] for r in md["related_identifiers"]]
+    assert any("release-2025-02-10" in i for i in idents)
+    assert any("release-2025-03-01" in i for i in idents)
+    assert "vintage V2" in md["title"]
+    # The description states the best-vs-first capture distinction.
+    assert "most" in md["description"] and "first" in md["description"]
+
+
+def test_deposited_tags_parses_related_identifiers():
+    tags = zenodo.deposited_tags([_version("2025-02-10"), _version("2024-08-02-1")])
+    assert tags == {"2025-02-10", "2024-08-02-1"}
+
+
+def test_run_deposit_dry_run_touches_nothing():
+    dep = zenodo.VintageDeposit(
+        vintage_id="V1", tags=["t"], publication_date="2024-08-02",
+        best_capture="t", files=[],
+    )
+    client = zenodo.ZenodoClient("https://example.invalid", "no-token")
+    assert zenodo.run_deposit(client, "0", dep, dry_run=True) is None


### PR DESCRIPTION
Implements M2 (#25, #26) and the code half of M3 (#27, #28) — everything short of the token-gated sandbox rehearsal.

## manifest.py (#25)
Per-release provenance: sha256, byte size, row counts, and **vintage derived by content hash** (audit correction: historical artifacts carry no vintage string). `manifests/` is checked in for all 19 historical releases; `data/vintages.json` maps release→vintage. The hash equivalence classes independently reproduce the audit's V1/V2/V3 grouping, including both defective partial scrapes and the 2026-05-28 scope-change boundary. `assign_vintage` verified: all real manifests map to their audited vintage; novel content → V4/new.

## normalize.py (#26)
Derived harmonized view; decisions are data (`data/crosswalks.json`), originals untouched. Fixes the audit defect list: locale_type re-derived from areatype (0 county-areatype rows left in `other`), leaked footnote rows dropped and counted (29,689 demographics / 4,649 risk in 2026-06-01 — matching the audit), race labels de-escaped with a canonical mapping **only where populations are semantically identical** (demographics 'Asian Non-Hispanic' deliberately unmapped — it is not incidence's A/PI), RUCC column renamed, (1)/(2)/(7) source markers extracted. Strict kept+dropped==original assertion. Validated end-to-end on the real 2026-06-01 release.

## Zenodo machinery (#27, #28)
`scps/zenodo.py` (testable core) + thin `scripts/zenodo/backfill.py` / `publish_release.py`. Idempotent: deposit plan keyed on GitHub tags in `related_identifiers`; re-running never duplicates. Best-capture bytes, first-capture `publication_date`, distinction stated in each version description. Sandbox vs production is config (base URL + record id + token secret). `--dry-run` exercised against the real release tree without credentials. Sequential uploads with retry/backoff per the API gotchas.

Not in this PR: CI workflow wiring (#29 — follows after #39 merges to avoid a workflow-file conflict) and the sandbox rehearsal itself (needs tokens, #19).

## Testing
76 tests pass (`uv run --extra dev pytest`): 13 new across manifest hashing/vintage assignment, each normalize defect, and deposit planning/idempotency/metadata. Plus the two live validations above (real-release harmonization; real-manifest vintage assignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)