### PR TITLE
M5 scaffold: descriptor.qmd + MANUSCRIPT_STATE.yaml

### DIFF
--- a/manuscript/MANUSCRIPT_STATE.yaml
+++ b/manuscript/MANUSCRIPT_STATE.yaml
@@ -1,0 +1,68 @@
+# scriptorium editorial state (seandavi/scriptorium). Bootstrapped from
+# SPEC.md §6 and the Task 0 audit; refine with scriptorium:init as drafting
+# proceeds.
+project:
+  title: >-
+    A versioned, analysis-ready archive of United States State Cancer
+    Profiles county- and state-level estimates
+  target_type: preprint
+  target_venue: medRxiv
+  candidate_venues:
+    - Scientific Data
+  source_format: quarto
+
+document_phase:
+  current: outline
+
+core_claims:
+  - >-
+    State Cancer Profiles offers no API, no bulk download, and no archive of
+    prior estimates; its sole machine-readable export returns one statistical
+    stratum per request (~18,900 requests for a national extract), and it
+    overwrites superseded estimates.
+  - >-
+    This resource publishes the complete national county- and state-level
+    extract of all four SCP data topics as typed, analysis-ready files with
+    the stratifying dimensions as columns, under pinned, citable version
+    DOIs — one per distinct upstream data vintage.
+  - >-
+    The archive preserves superseded vintages that no live query client can
+    recover; ~98% of estimate values were revised at each observed vintage
+    boundary, so vintage identity materially affects downstream analysis.
+  - >-
+    From the first post-hardening release forward, suppressed cells are
+    decoded into typed nulls with an explicit suppression-reason column,
+    distinguishing small-count suppression from state-law withholding.
+
+known_weaknesses:
+  - Only three vintages captured to date; the archive is primarily a prospective record.
+  - Vintage boundaries are bracketed by release gaps, not dated; intermediate upstream vintages could have gone uncaptured.
+  - Historical releases (V1-V3) are CSV-only and dropped suppressed rows; suppression there is recoverable only by cross-product differencing.
+  - Kansas county incidence is absent in every vintage; Indiana county incidence exists only from V3.
+  - Demographics race categories only partially map to the incidence/mortality vocabulary; unmappable categories remain topic-local.
+
+terminology:
+  preferred:
+    vintage: a distinct set of upstream SCP estimates, identified by content
+    release: a dated scrape published as a GitHub release; several releases may capture one vintage
+    suppression: upstream withholding of a cell (small-count or state-law)
+    harmonized view: the derived cross-vintage artifact; never a modification of release bytes
+    stratum: one (site x race x sex x age x stage x areatype) query combination
+  forbidden:
+    - version (ambiguous; use vintage or release)
+    - snapshot (use capture or release)
+  synonyms:
+    capture: release
+
+style:
+  tone: descriptive, restrained; data descriptor genre — no analysis, no conclusions
+  voice: active
+  audience: cancer surveillance researchers, health geographers, data engineers
+
+constraints:
+  preserve_citations: true
+  preserve_statistics: true
+  avoid_hype: true
+
+bibliography:
+  path: refs.bib

--- a/manuscript/MANUSCRIPT_STATE.yaml
+++ b/manuscript/MANUSCRIPT_STATE.yaml
@@ -39,6 +39,7 @@ known_weaknesses:
   - Vintage boundaries are bracketed by release gaps, not dated; intermediate upstream vintages could have gone uncaptured.
   - Historical releases (V1-V3) are CSV-only and dropped suppressed rows; suppression there is recoverable only by cross-product differencing.
   - Kansas county incidence is absent in every vintage; Indiana county incidence exists only from V3.
+  - Historical mortality tables are 50% duplicated (phantom stage dimension); rows labelled late-stage there carry all-stages rates. Fixed prospectively; historical counts must be deduplicated.
   - Demographics race categories only partially map to the incidence/mortality vocabulary; unmappable categories remain topic-local.
 
 terminology:

--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -95,6 +95,10 @@ for r in rows:
 ```
 
 <!-- To add, each as a chunk:
+- mortality row counts in historical releases (V1-V3) MUST be deduplicated
+  first: the stage dimension is phantom for mortality and 50% of rows are
+  duplicates carrying a wrong late-stage label (issue #43; fixed from the
+  first post-hardening release);
 - vintage-boundary revision fractions (~98%) recomputed from the deposits;
 - suppression census (post-hardening releases) by state and reason;
 - coverage table: Kansas incidence absence, Indiana V3 return, V1 gaps;

--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -1,0 +1,133 @@
+---
+title: >-
+  A versioned, analysis-ready archive of United States State Cancer Profiles
+  county- and state-level estimates
+author:
+  - name: Sean Davis
+    orcid: 0000-0002-8991-6458
+    affiliations:
+      - University of Colorado Anschutz Medical Campus
+bibliography: refs.bib
+format:
+  pdf:
+    keep-tex: true
+execute:
+  freeze: auto
+  echo: false
+---
+
+<!--
+Scaffold only. Genre and claim-scoping rules: manuscript/CLAUDE.md.
+Every number in Technical Validation comes from an executable chunk reading
+the deposited artifacts or the checked-in manifests — never typed.
+The abstract is written LAST, from the finished sections.
+-->
+
+# Abstract {.unnumbered}
+
+<!-- TODO: write last. Reuse-value argument leads; the vintage archive
+differentiates. Honest vintage count (3, prospective record). -->
+
+# Background & Summary
+
+<!-- Draft plan (SPEC §6):
+- SCP: what it is, who uses it; no API, no bulk download, no archive
+  (dated verification: docs/no-bulk-access.md; wording template there).
+- The access problem: one stratum per request; ~18,852 requests per
+  national extract (computed below, not typed).
+- The overwrite problem: superseded estimates unrecoverable; ~98% of values
+  revised per vintage boundary.
+- Prior art: cancerprof (cite accurately: rOpenSci review closed without
+  acceptance, never on CRAN); RStateCancerProfiles (2016, abandoned);
+  CIFTools/Cancer InFocus (dashboard pipeline, no published dataset);
+  CRAN packages bundling hand-frozen one-off SCP slices (latticeExtra,
+  SeerMapper, spGARCH) as motivating evidence; no third-party full extract
+  deposited in any generalist repository.
+- This resource: what it is, complementary to cancerprof, not competing.
+-->
+
+# Methods
+
+<!-- Draft plan:
+- LEAD with suppression decoding (scoped: releases from the hardened
+  scraper forward; historical releases dropped suppressed rows — say so).
+- Scrape design: vocabulary discovered from the live site; one request per
+  stratum; catalog of known-good combinations; regression oracle.
+- Content-based payload parsing; notes preservation (vintage provenance).
+- Vintage identification by content hash (docs/releases.md method).
+- Harmonized view: crosswalks as data; strict accounting.
+- Zenodo archiving: one version DOI per vintage; best-capture bytes,
+  first-capture publication_date.
+-->
+
+# Data Records
+
+```{python}
+#| label: tbl-vintages
+#| output: asis
+import json, pathlib
+v = json.loads(pathlib.Path("../data/vintages.json").read_text())["vintages"]
+print("| Vintage | Releases | First captured | Best capture |")
+print("|---|---|---|---|")
+for vid, info in sorted(v.items()):
+    print(f"| {vid} | {len(info['releases'])} | {info['first_capture']} | {info['best_capture']} |")
+```
+
+<!-- Per-vintage DOI table once the backfill has run; file inventory from
+manifests/; schema description per topic. -->
+
+# Technical Validation
+
+```{python}
+#| label: tbl-release-integrity
+#| output: asis
+import json, pathlib
+rows = []
+for p in sorted(pathlib.Path("../manifests").glob("*.json")):
+    m = json.loads(p.read_text())
+    for f in m["files"]:
+        if f.get("topic"):
+            rows.append((m["tag"], f["topic"], f["rows"], f["sha256"][:12]))
+print("| Release | Topic | Rows | sha256 (12) |")
+print("|---|---|---|---|")
+for r in rows:
+    print("| " + " | ".join(str(x) for x in r) + " |")
+```
+
+<!-- To add, each as a chunk:
+- vintage-boundary revision fractions (~98%) recomputed from the deposits;
+- suppression census (post-hardening releases) by state and reason;
+- coverage table: Kansas incidence absence, Indiana V3 return, V1 gaps;
+- schema stability matrix (a finding, not drift);
+- cross-topic join demonstration — run it before claiming it
+  (race_canonical mapping; unmapped categories stated).
+-->
+
+# Usage Notes
+
+<!-- Must state (SPEC §6 + audit):
+- incidence and mortality cover different five-year windows; consecutive
+  vintages share four of five years — not independent observations; never
+  naively difference them.
+- SCP displays but excludes 2020 incidence from trend fits.
+- Kansas: no county incidence in any vintage; county mortality complete —
+  incidence x mortality joins drop Kansas asymmetrically.
+- Indiana county incidence exists only from V3.
+- Pre-2026-05-28 releases: filter on areatype, not locale_type; the
+  harmonized view fixes this.
+- Suppression semantics differ between historical (rows absent) and
+  post-hardening (typed nulls + reason) releases.
+-->
+
+# Code availability {.unnumbered}
+
+<!-- Repo, license, per-release gh_hash.txt pinning scraper commit. -->
+
+## Funding {.unnumbered}
+
+<!-- P30CA046934 only; verify exact CCSG wording with the grants
+administrator before posting. Rifkin-Bennis endowment alongside. -->
+
+## AI use disclosure {.unnumbered}
+
+<!-- Plain-language statement per SPEC §7. -->

--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -44,6 +44,15 @@ differentiates. Honest vintage count (3, prospective record). -->
   SeerMapper, spGARCH) as motivating evidence; no third-party full extract
   deposited in any generalist repository.
 - This resource: what it is, complementary to cancerprof, not competing.
+- Bulk claim wording (falsifiable otherwise): "nobody else has PUBLISHED
+  the result as a versioned citable dataset" — CIFTools (Cancer InFocus
+  data layer) is an unpublished national sweep; verify its attribution
+  by hand before naming the group (docs/landscape-literature.md §1a).
+- Vintage anchor citations: croushore2001realtime / croushore2003vintage
+  (economics lineage, introduce as analogy) and clegg2002reportingdelay
+  (SEER reporting-delay revisions flipped trend signs — the cancer-domain
+  demonstration). Demand evidence: burus2025cifimpact (26 NCI-designated
+  centers licensing Cancer InFocus). Genre model: hasell2020testing.
 -->
 
 # Methods
@@ -120,7 +129,17 @@ for r in rows:
 - Pre-2026-05-28 releases: filter on areatype, not locale_type; the
   harmonized view fixes this.
 - Suppression semantics differ between historical (rows absent) and
-  post-hardening (typed nulls + reason) releases.
+  post-hardening (typed nulls + reason) releases. The archive does NOT
+  un-suppress anything — cite jacobson2026pediatric / ladas2026melanoma /
+  kasheri2026dermatologist as the documented failure mode the reason
+  columns make countable.
+- Risk/screening estimates are MODELLED small-area estimates
+  (raghunathan2007combining, liu2019smallarea), not registry-observed —
+  different epistemic status from incidence/mortality; they can change
+  between vintages because the model was refit.
+- Trend columns are Joinpoint outputs whose software defaults have
+  changed over time (kim2022twentyyears): do not compare AAPC across
+  vintages without checking the producing version.
 -->
 
 # Code availability {.unnumbered}

--- a/manuscript/refs.bib
+++ b/manuscript/refs.bib
@@ -1,0 +1,2 @@
+% Populated by the landscape literature pass (issue #30).
+% Every entry verified against its DOI/PMID before inclusion — no unverified citations.

--- a/manuscript/refs.bib
+++ b/manuscript/refs.bib
@@ -1,2 +1,675 @@
-% Populated by the landscape literature pass (issue #30).
-% Every entry verified against its DOI/PMID before inclusion — no unverified citations.
+% refs.bib — landscape literature for the State Cancer Profiles archive data descriptor
+% SPEC.md §5 (issue #30), literature strands. Prepared 2026-08-23.
+%
+% VERIFICATION RULE APPLIED: every entry below was retrieved from PubMed (via the
+% PubMed MCP) or from Crossref/publisher metadata during this session. Volume, issue,
+% page and DOI fields are copied from that retrieved metadata, not reconstructed.
+% Entries that could not be verified are listed in the UNVERIFIED block at the end
+% and are deliberately left as comments — do not cite them without checking.
+
+
+% =====================================================================
+% STRAND 2c — Joinpoint / AAPC methodology, as State Cancer Profiles applies it
+% =====================================================================
+
+@article{kim2000permutation,
+  author  = {Kim, Hyune-Ju and Fay, Michael P. and Feuer, Eric J. and Midthune, Douglas N.},
+  title   = {Permutation tests for joinpoint regression with applications to cancer rates},
+  journal = {Statistics in Medicine},
+  year    = {2000},
+  volume  = {19},
+  number  = {3},
+  pages   = {335--351},
+  doi     = {10.1002/(SICI)1097-0258(20000215)19:3<335::AID-SIM336>3.0.CO;2-Z},
+  note    = {PMID: 10649300}
+}
+
+@article{clegg2009aapc,
+  author  = {Clegg, Limin X. and Hankey, Benjamin F. and Tiwari, Ram and Feuer, Eric J. and Edwards, Brenda K.},
+  title   = {Estimating average annual per cent change in trend analysis},
+  journal = {Statistics in Medicine},
+  year    = {2009},
+  volume  = {28},
+  number  = {29},
+  pages   = {3670--3682},
+  doi     = {10.1002/sim.3733},
+  note    = {PMID: 19856324}
+}
+
+@article{kim2022twentyyears,
+  author  = {Kim, Hyune-Ju and Chen, Huann-Sheng and Byrne, Jeffrey and Wheeler, Bill and Feuer, Eric J.},
+  title   = {Twenty years since {Joinpoint} 1.0: Two major enhancements, their justification, and impact},
+  journal = {Statistics in Medicine},
+  year    = {2022},
+  volume  = {41},
+  number  = {16},
+  pages   = {3102--3130},
+  doi     = {10.1002/sim.9407},
+  note    = {PMID: 35522060}
+}
+
+@article{kim2023modelselection,
+  author  = {Kim, Hyune-Ju and Chen, Huann-Sheng and Midthune, Douglas and Wheeler, Bill and Buckman, Dennis W. and Green, Donald and Byrne, Jeffrey and Luo, Jun and Feuer, Eric J.},
+  title   = {Data-driven choice of a model selection method in joinpoint regression},
+  journal = {Journal of Applied Statistics},
+  year    = {2023},
+  volume  = {50},
+  number  = {9},
+  pages   = {1992--2013},
+  doi     = {10.1080/02664763.2022.2063265},
+  note    = {PMID: 37378270; PMC10291945}
+}
+
+
+% =====================================================================
+% STRAND 2b — Small-area suppression, disclosure limitation, and
+%             downstream-analysis effects
+% =====================================================================
+
+@article{tatalovich2022zonedesign,
+  author  = {Tatalovich, Zaria and Stinchcomb, David G. and Ng, Diane and Yu, Mandi and Lewis, Denise R. and Zhu, Li and Feuer, Eric J.},
+  title   = {Developing Geographic Areas for Cancer Reporting Using Automated Zone Design},
+  journal = {American Journal of Epidemiology},
+  year    = {2022},
+  volume  = {191},
+  number  = {12},
+  pages   = {2109--2119},
+  doi     = {10.1093/aje/kwac155},
+  note    = {PMID: 36043397}
+}
+
+@article{klein2002suppression,
+  author  = {Klein, Richard J. and Proctor, Suzanne E. and Boudreault, Manon A. and Turczyn, Kathleen M.},
+  title   = {Healthy People 2010 criteria for data suppression},
+  journal = {Healthy People 2010 Statistical Notes},
+  year    = {2002},
+  number  = {24},
+  pages   = {1--12},
+  institution = {National Center for Health Statistics},
+  address = {Hyattsville, MD},
+  note    = {PMID: 12117004; DHHS Publication No. (PHS) 2002-1237; no DOI assigned}
+}
+
+@article{parker2017proportions,
+  author  = {Parker, Jennifer D. and Talih, Makram and Malec, Donald J. and Beresovsky, Vladislav and Carroll, Margaret and Gonzalez, Joe F. and Hamilton, Brady E. and Ingram, Deborah D. and Kochanek, Kenneth and McCarty, Frances and Moriarity, Chris and Shimizu, Iris and Strashny, Alexander and Ward, Brian W.},
+  title   = {National Center for Health Statistics Data Presentation Standards for Proportions},
+  journal = {Vital and Health Statistics, Series 2},
+  year    = {2017},
+  number  = {175},
+  pages   = {1--22},
+  note    = {PMID: 30248016; DHHS Publication No. 2017-1375; no DOI assigned}
+}
+
+@article{talih2023ratesstandards,
+  author  = {Talih, Makram and Irimata, Katherine E. and Zhang, Guangyu and Parker, Jennifer D.},
+  title   = {Evaluation of the National Center for Health Statistics Data Presentation Standards for Rates From Vital Statistics and Sample Surveys},
+  journal = {Vital and Health Statistics, Series 1},
+  year    = {2023},
+  number  = {198},
+  pages   = {1--30},
+  note    = {PMID: 36940136; no DOI assigned}
+}
+
+@article{santoslozada2020dp,
+  author  = {Santos-Lozada, Alexis R. and Howard, Jeffrey T. and Verdery, Ashton M.},
+  title   = {How differential privacy will affect our understanding of health disparities in the {United States}},
+  journal = {Proceedings of the National Academy of Sciences},
+  year    = {2020},
+  volume  = {117},
+  number  = {24},
+  pages   = {13405--13412},
+  doi     = {10.1073/pnas.2003714117},
+  note    = {PMID: 32467167}
+}
+
+@article{krieger2021dp,
+  author  = {Krieger, Nancy and Nethery, Rachel C. and Chen, Jarvis T. and Waterman, Pamela D. and Wright, Emily and Rushovich, Tamara and Coull, Brent A.},
+  title   = {Impact of Differential Privacy and Census Tract Data Source ({Decennial Census} Versus {American Community Survey}) for Monitoring Health Inequities},
+  journal = {American Journal of Public Health},
+  year    = {2021},
+  volume  = {111},
+  number  = {2},
+  pages   = {265--268},
+  doi     = {10.2105/AJPH.2020.305989},
+  note    = {PMID: 33351654}
+}
+
+@article{li2023dpmapping,
+  author  = {Li, Yanran and Coull, Brent A. and Krieger, Nancy and Peterson, Emily and Waller, Lance A. and Chen, Jarvis T. and Nethery, Rachel C.},
+  title   = {Impacts of census differential privacy for small-area disease mapping to monitor health inequities},
+  journal = {Science Advances},
+  year    = {2023},
+  volume  = {9},
+  number  = {33},
+  pages   = {eade8888},
+  doi     = {10.1126/sciadv.ade8888},
+  note    = {PMID: 37595037}
+}
+
+@article{kurz2022dpmedicaid,
+  author  = {Kurz, Christoph F. and K{\"o}nig, Adriana N. and Emmert-Fees, Karl M. F. and Allen, Lindsay D.},
+  title   = {The effect of differential privacy on {Medicaid} participation among racial and ethnic minority groups},
+  journal = {Health Services Research},
+  year    = {2022},
+  volume  = {57},
+  number  = {S2},
+  pages   = {207--213},
+  doi     = {10.1111/1475-6773.14000},
+  note    = {PMID: 35524543}
+}
+
+@article{rushton2006geocoding,
+  author  = {Rushton, Gerard and Armstrong, Marc P. and Gittler, Josephine and Greene, Barry R. and Pavlik, Claire E. and West, Michele M. and Zimmerman, Dale L.},
+  title   = {Geocoding in cancer research: a review},
+  journal = {American Journal of Preventive Medicine},
+  year    = {2006},
+  volume  = {30},
+  number  = {2, Suppl.},
+  pages   = {S16--S24},
+  doi     = {10.1016/j.amepre.2005.09.011},
+  note    = {PMID: 16458786}
+}
+
+
+% =====================================================================
+% STRAND 2a — Data vintage and estimate revision in official statistics
+% =====================================================================
+
+% -- The mature (economics) version of the idea: real-time vintage datasets.
+@article{croushore2001realtime,
+  author  = {Croushore, Dean and Stark, Tom},
+  title   = {A real-time data set for macroeconomists},
+  journal = {Journal of Econometrics},
+  year    = {2001},
+  volume  = {105},
+  number  = {1},
+  pages   = {111--130},
+  doi     = {10.1016/S0304-4076(01)00072-0}
+}
+
+@article{croushore2003vintage,
+  author  = {Croushore, Dean and Stark, Tom},
+  title   = {A Real-Time Data Set for Macroeconomists: Does the Data Vintage Matter?},
+  journal = {The Review of Economics and Statistics},
+  year    = {2003},
+  volume  = {85},
+  number  = {3},
+  pages   = {605--617},
+  doi     = {10.1162/003465303322369759}
+}
+
+% -- The health-surveillance analogue: cancer incidence estimates are revised
+%    upward for years after first publication.
+@article{clegg2002reportingdelay,
+  author  = {Clegg, Limin X. and Feuer, Eric J. and Midthune, Douglas N. and Fay, Michael P. and Hankey, Benjamin F.},
+  title   = {Impact of reporting delay and reporting error on cancer incidence rates and trends},
+  journal = {Journal of the National Cancer Institute},
+  year    = {2002},
+  volume  = {94},
+  number  = {20},
+  pages   = {1537--1545},
+  doi     = {10.1093/jnci/94.20.1537},
+  note    = {PMID: 12381706}
+}
+
+@article{das2008completeness,
+  author  = {Das, Barnali and Clegg, Limin X. and Feuer, Eric J. and Pickle, Linda W.},
+  title   = {A new method to evaluate the completeness of case ascertainment by a cancer registry},
+  journal = {Cancer Causes \& Control},
+  year    = {2008},
+  volume  = {19},
+  number  = {5},
+  pages   = {515--525},
+  doi     = {10.1007/s10552-008-9114-0},
+  note    = {PMID: 18270798}
+}
+
+% -- Data-versioning practice as a research-infrastructure concern.
+@article{klump2021versioning,
+  author  = {Klump, Jens and Wyborn, Lesley and Wu, Mingfang and Martin, Julia and Downs, Robert R. and Asmi, Ari},
+  title   = {Versioning Data Is About More than Revisions: A Conceptual Framework and Proposed Principles},
+  journal = {Data Science Journal},
+  year    = {2021},
+  volume  = {20},
+  pages   = {12},
+  doi     = {10.5334/dsj-2021-012}
+}
+
+@article{gonzalezcebrian2024versioning,
+  author  = {Gonz{\'a}lez-Cebri{\'a}n, Alba and Bradford, Michael and Chis, Adriana E. and Gonz{\'a}lez-V{\'e}lez, Horacio},
+  title   = {Standardised Versioning of Datasets: a {FAIR}-compliant Proposal},
+  journal = {Scientific Data},
+  year    = {2024},
+  volume  = {11},
+  number  = {1},
+  pages   = {358},
+  doi     = {10.1038/s41597-024-03153-y},
+  note    = {PMID: 38594314}
+}
+
+
+% =====================================================================
+% UPSTREAM METHODOLOGY — how State Cancer Profiles itself produces its
+% screening and risk-factor numbers (they are modelled, not observed)
+% =====================================================================
+
+@article{raghunathan2007combining,
+  author  = {Raghunathan, Trivellore E. and Xie, Dawei and Schenker, Nathaniel and Parsons, Van L. and Davis, William W. and Dodd, Kevin W. and Feuer, Eric J.},
+  title   = {Combining Information From Two Surveys to Estimate County-Level Prevalence Rates of Cancer Risk Factors and Screening},
+  journal = {Journal of the American Statistical Association},
+  year    = {2007},
+  volume  = {102},
+  number  = {478},
+  pages   = {474--486},
+  doi     = {10.1198/016214506000001293}
+}
+
+@article{liu2019smallarea,
+  author  = {Liu, Benmei and Parsons, Van and Feuer, Eric J. and Pan, Qiang and Town, Machell and Raghunathan, Trivellore E. and Schenker, Nathaniel and Xie, Dawei},
+  title   = {Small Area Estimation of Cancer Risk Factors and Screening Behaviors in {US} Counties by Combining Two Large National Health Surveys},
+  journal = {Preventing Chronic Disease},
+  year    = {2019},
+  volume  = {16},
+  pages   = {E119},
+  doi     = {10.5888/pcd16.190013},
+  note    = {PMID: 31469068}
+}
+
+@article{liu2025psa,
+  author  = {Liu, Benmei and Pleis, John R. and Khan, Diba and Parsons, Van L. and Lee, Richard and Cai, Bill and Town, Machell and Feuer, Eric J. and He, Yulei},
+  title   = {Small Area Estimation of {PSA} Testing in {US} States and Counties},
+  journal = {Cancer Epidemiology, Biomarkers \& Prevention},
+  year    = {2025},
+  volume  = {34},
+  number  = {1},
+  pages   = {197--204},
+  doi     = {10.1158/1055-9965.EPI-24-1086},
+  note    = {PMID: 39513937}
+}
+
+
+% =====================================================================
+% STRAND 3 — Genre precedent: data descriptors built on scraped or
+%            re-extracted public/government data
+% =====================================================================
+
+@article{hasell2020testing,
+  author  = {Hasell, Joe and Mathieu, Edouard and Beltekian, Diana and Macdonald, Bobbie and Giattino, Charlie and Ortiz-Ospina, Esteban and Roser, Max and Ritchie, Hannah},
+  title   = {A cross-country database of {COVID-19} testing},
+  journal = {Scientific Data},
+  year    = {2020},
+  volume  = {7},
+  number  = {1},
+  pages   = {345},
+  doi     = {10.1038/s41597-020-00688-8},
+  note    = {PMID: 33033256}
+}
+
+@article{xu2020covidcases,
+  author  = {Xu, Bo and Gutierrez, Bernardo and Mekaru, Sumiko and Sewalk, Kara and Goodwin, Lauren and Loskill, Alyssa and Cohn, Emily L. and Hswen, Yulin and Hill, Sarah C. and Cobo, Maria M. and Zarebski, Alexander E. and Li, Sabrina and Wu, Chieh-Hsi and Hulland, Erin and Morgan, Julia D. and Wang, Lin and O'Brien, Katelynn and Scarpino, Samuel V. and Brownstein, John S. and Pybus, Oliver G. and Pigott, David M. and Kraemer, Moritz U. G.},
+  title   = {Epidemiological data from the {COVID-19} outbreak, real-time case information},
+  journal = {Scientific Data},
+  year    = {2020},
+  volume  = {7},
+  number  = {1},
+  pages   = {106},
+  doi     = {10.1038/s41597-020-0448-0},
+  note    = {PMID: 32210236}
+}
+
+@article{vanheusden2025foia,
+  author  = {van Heusden, Ruben and Larooij, Maik and Kamps, Jaap and Marx, Maarten},
+  title   = {A collection of {FAIR} {Dutch} {Freedom of Information Act} documents},
+  journal = {Scientific Data},
+  year    = {2025},
+  volume  = {12},
+  number  = {1},
+  pages   = {795},
+  doi     = {10.1038/s41597-025-05052-2},
+  note    = {PMID: 40374651}
+}
+
+@article{ocagli2024jecfa,
+  author  = {Ocagli, Honoria and Lanera, Corrado and Franzoi, Marco and Monachesi, Chiara and Zgheib, Rebecca and Belluco, Simone and Dacasto, Mauro and Gregori, Dario and Baldi, Ileana},
+  title   = {Unveiling insights from the {Joint FAO/WHO Expert Committee on Food Additives (JECFA)} portal},
+  journal = {Scientific Data},
+  year    = {2024},
+  volume  = {11},
+  number  = {1},
+  pages   = {1443},
+  doi     = {10.1038/s41597-024-04294-w},
+  note    = {PMID: 39732706}
+}
+
+@article{karnik2025offsets,
+  author  = {Karnik, Akshata and Kilbride, John B. and Goodbody, Tristan R. H. and Ross, Rachael and Ayrey, Elias},
+  title   = {An open-access database of nature-based carbon offset project boundaries},
+  journal = {Scientific Data},
+  year    = {2025},
+  volume  = {12},
+  number  = {1},
+  pages   = {581},
+  doi     = {10.1038/s41597-025-04868-2},
+  note    = {PMID: 40188135}
+}
+
+@article{zhang2025adtransparency,
+  author  = {Zhang, Meiqing and Cakmak, Furkan and Neumann, Markus and Zimmeck, Sebastian and Oleinikov, Pavel and Yao, Jielu and Yu, Harry and Jacewicz, Aleks and Tassone, Isabella and Floyd, Breeze and Baum, Laura and Franz, Michael M. and Ridout, Travis N. and Fowler, Erika Franklin},
+  title   = {Comparable 2022 General Election Advertising Datasets from {Meta} and {Google}},
+  journal = {Scientific Data},
+  year    = {2025},
+  volume  = {12},
+  number  = {1},
+  pages   = {968},
+  doi     = {10.1038/s41597-025-05228-w},
+  note    = {PMID: 40490478}
+}
+
+
+% =====================================================================
+% DEMONSTRATED REUSE OF STATE CANCER PROFILES — evidence of demand, and
+% published, citable evidence that suppression is a live analytic barrier
+% =====================================================================
+
+@article{jacobson2026pediatric,
+  author  = {Jacobson, Ingrid and Levasseur, Luke and Hankins, Laura and Kamboj, Aryan and Schroeder, Zachary},
+  title   = {Pediatric and Adolescent Cancer Incidence Rates in 29 Non-Metropolitan {US} Counties: An Analysis of Publicly Available Data},
+  journal = {Pediatric Blood \& Cancer},
+  year    = {2026},
+  volume  = {73},
+  number  = {8},
+  pages   = {e70407},
+  doi     = {10.1002/1545-5017.70407},
+  note    = {PMID: 42136043}
+}
+
+@article{ladas2026melanoma,
+  author  = {Ladas, George and Towery, Derek S.},
+  title   = {Melanoma Incidence, Mortality, and Dermatologist Availability Across Selected Urban and Rural Counties in Southwest {Missouri}},
+  journal = {Cureus},
+  year    = {2026},
+  volume  = {18},
+  number  = {3},
+  pages   = {e105007},
+  doi     = {10.7759/cureus.105007},
+  note    = {PMID: 41994662}
+}
+
+@article{kasheri2026dermatologist,
+  author  = {Kasheri, Eli and Dan, Joshua and Nouri, Keyvan},
+  title   = {Higher dermatologist density is associated with lower proportions of late-stage melanoma: An ecological study of the {State Cancer Profiles}},
+  journal = {Journal of the American Academy of Dermatology},
+  year    = {2026},
+  volume  = {95},
+  number  = {3},
+  pages   = {662--669},
+  doi     = {10.1016/j.jaad.2026.05.029},
+  note    = {PMID: 42144199}
+}
+
+@article{crowley2026oncologists,
+  author  = {Crowley, Ryan J. and Lally, Jag S. and Kline, David M. and Bunting, Amanda M.},
+  title   = {Geographic disparities in access to oncologists and association with cancer outcomes in the {United States}},
+  journal = {Journal of Cancer Policy},
+  year    = {2026},
+  volume  = {47},
+  pages   = {100704},
+  doi     = {10.1016/j.jcpo.2026.100704},
+  note    = {PMID: 41500462}
+}
+
+@article{drake2025community,
+  author  = {Drake, Alexandra R. and Christensen, Eric W. and Ochoa, Augusto C. and Small, William and Scott, Jinel and Rula, Elizabeth Y.},
+  title   = {Community Factors and County-Level Cancer Screening, Prevalence, and Mortality},
+  journal = {JAMA Network Open},
+  year    = {2025},
+  volume  = {8},
+  number  = {10},
+  pages   = {e2537690},
+  doi     = {10.1001/jamanetworkopen.2025.37690},
+  note    = {PMID: 41129153}
+}
+
+@article{zhang2024oncologydensity,
+  author  = {Zhang, Yuehan and Leifheit, Kathryn M. and Lee, Kimberley T. and Thorpe, Roland J. and Gaskin, Darrell J. and Dean, Lorraine T.},
+  title   = {The Association of Oncology Provider Density With {Black}-{White} Disparities in Cancer Mortality in {US} Counties},
+  journal = {Cancer Control},
+  year    = {2024},
+  volume  = {31},
+  pages   = {10732748241244929},
+  doi     = {10.1177/10732748241244929},
+  note    = {PMID: 38607968}
+}
+
+@article{wei2025tanning,
+  author  = {Wei, Guixing and Tran, Megan M. and Orsillo, Lauryn and Mirza, Fatima N. and Yumeen, Sara and Yang, Eric and Robbins, Allison and Mehta, Aakash and Liu, Zhijun and Vance, Terrence and Kawaoka, John and Qureshi, Abrar A. and Wisco, Oliver J.},
+  title   = {A Geospatial Analysis of the Association between Access to Tanning Bed Facilities and Melanoma in the {United States} {New England} Region},
+  journal = {Journal of Investigative Dermatology},
+  year    = {2025},
+  volume  = {145},
+  number  = {4},
+  pages   = {876--882},
+  doi     = {10.1016/j.jid.2024.04.038},
+  note    = {PMID: 39520451}
+}
+
+@article{joseph2022pesticides,
+  author  = {Joseph, Naveen and Propper, Catherine R. and Goebel, Madeline and Henry, Shantel and Roy, Indrakshi and Kolok, Alan S.},
+  title   = {Investigation of Relationships Between the Geospatial Distribution of Cancer Incidence and Estimated Pesticide Use in the {U.S. West}},
+  journal = {GeoHealth},
+  year    = {2022},
+  volume  = {6},
+  number  = {5},
+  pages   = {e2021GH000544},
+  doi     = {10.1029/2021GH000544},
+  note    = {PMID: 35599961}
+}
+
+@article{shalowitz2015geographic,
+  author  = {Shalowitz, David I. and Vinograd, Alexandra M. and Giuntoli, Robert L.},
+  title   = {Geographic access to gynecologic cancer care in the {United States}},
+  journal = {Gynecologic Oncology},
+  year    = {2015},
+  volume  = {138},
+  number  = {1},
+  pages   = {115--120},
+  doi     = {10.1016/j.ygyno.2015.04.025},
+  note    = {PMID: 25922191}
+}
+
+
+% =====================================================================
+% ADJACENT TOOLING — catchment-area surveillance platforms
+% =====================================================================
+
+@article{burus2023cancerinfocus,
+  author  = {Burus, Justin Todd and Park, Lee and McAfee, Caree R. and Wilhite, Natalie P. and Hull, Pamela C.},
+  title   = {Cancer {InFocus}: Tools for Cancer Center Catchment Area Geographic Data Collection and Visualization},
+  journal = {Cancer Epidemiology, Biomarkers \& Prevention},
+  year    = {2023},
+  volume  = {32},
+  number  = {7},
+  pages   = {889--893},
+  doi     = {10.1158/1055-9965.EPI-22-1319},
+  note    = {PMID: 37222667; PMCID: PMC10320460. Primary citation for Cancer InFocus.
+             Pagination confirmed against Crossref; PubMed still carries the
+             ahead-of-print form OF1--OF5 --- use 889--893}
+}
+
+@article{sonawane2024dashboards,
+  author  = {Sonawane, Kalyani and Borse, Ketki N. and Jefferson, Melanie and Damgacioglu, Haluk and Carpenter, Matthew J. and Pearce, John L. and Ogretmen, Besim and Paczesny, Sophie and O'Bryan, John P. and Obeid, Jihad S. and Ford, Marvella E. and Deshmukh, Ashish A.},
+  title   = {Developing Catchment Area Data Dashboards for Cancer Centers: A Stakeholder-engaged Approach},
+  journal = {Preventive Oncology \& Epidemiology},
+  year    = {2024},
+  volume  = {2},
+  number  = {1},
+  doi     = {10.1080/28322134.2024.2394193},
+  note    = {PMID: 40241913; PMCID: PMC12002557. MUSC Hollings}
+}
+
+
+% =====================================================================
+% STRAND 1 — Other software and data prior art
+% =====================================================================
+
+% -- The only other genuine national SCP sweep found anywhere. No release, no
+%    tag, no package-registry entry, no DOI. Cite as a repository with an
+%    access date; there is no canonical citation for it.
+@misc{ciodata_ciftools,
+  author       = {{Community Impact Office, Markey Cancer Center, University of Kentucky}},
+  title        = {{CIFTools}: Cancer {InFocus} data collection tools},
+  howpublished = {GitHub repository},
+  year         = {2025},
+  url          = {https://github.com/CIOData/CIFTools_update},
+  note         = {\texttt{src/cancer\_in\_focus\_data/state\_cancer\_profile.py} performs a
+                  national \texttt{stateFIPS=00\&areatype=county} sweep with retry/backoff.
+                  No release, tag, registry entry or DOI; not documented as a standalone
+                  library. Attribution to the Cancer InFocus team is inferred from the
+                  GitHub org identity, not stated on the repo --- verify before asserting it}
+}
+
+% -- Earliest known SCP client; abandoned January 2017.
+@misc{silentspring_rscp,
+  author       = {{Silent Spring Institute}},
+  title        = {{RStateCancerProfiles}: an {R} package for accessing {State Cancer Profiles} data},
+  howpublished = {GitHub repository},
+  year         = {2017},
+  url          = {https://github.com/SilentSpringInstitute/RStateCancerProfiles},
+  note         = {Apache-2.0; 15 commits; last commit 2017-01-03; never released on CRAN}
+}
+
+% -- Three CRAN packages that ship frozen one-off SCP exports as example data.
+%    None is a client. Collectively the best illustration of the problem.
+@manual{sarkar_latticeextra,
+  title  = {{latticeExtra}: Extra Graphical Utilities Based on Lattice},
+  author = {Sarkar, Deepayan and Andrews, Felix},
+  year   = {2025},
+  url    = {https://CRAN.R-project.org/package=latticeExtra},
+  note   = {R package version 0.6-31. Ships \texttt{USCancerRates}: 3{,}041 counties,
+            all-cancer death rates by sex, 1999--2003, sourced from State Cancer Profiles}
+}
+
+@manual{pearson_seermapper,
+  title  = {{SeerMapper}: A Quick Way to Map U.S. Rates and Data of U.S. States, Counties, Census Tracts, or Seer Registries},
+  author = {Pearson, Jim},
+  year   = {2021},
+  url    = {https://CRAN.R-project.org/package=SeerMapper},
+  note   = {R package version 1.2.5. Ships all-site mortality 2009--2013 for GA, WA, KY
+            and CA counties, hand-exported from State Cancer Profiles on 2 September 2016}
+}
+
+@manual{otto_spgarch,
+  title  = {{spGARCH}: Spatial {ARCH} and {GARCH} Models},
+  author = {Otto, Philipp},
+  year   = {2025},
+  url    = {https://CRAN.R-project.org/package=spGARCH},
+  note   = {R package version 0.2.3. Ships \texttt{prostate\_cancer}: log incidence rates,
+            2008--2012, nine southeastern states, from State Cancer Profiles}
+}
+
+% -- The only third-party SCP-derived deposit found in any data repository.
+@misc{acharjee2020airquality,
+  author    = {Acharjee, Mithun and Das, Kumer Pial and Young, S. Stanley},
+  title     = {Air Quality--Lung Cancer Data},
+  year      = {2020},
+  publisher = {Harvard Dataverse},
+  doi       = {10.7910/DVN/HMOEJO},
+  note      = {County-level 2010--2014 lung cancer incidence abstracted from NCI State
+               Cancer Profiles. Single site, single measure, single window --- an analysis
+               slice, not an extract}
+}
+
+@article{lowery2026ecco,
+
+@article{burus2025cifimpact,
+  author  = {Burus, Todd and McAfee, Caree R. and Wilhite, Natalie P. and Hull, Pamela C.},
+  title   = {Measuring the impact of a catchment area surveillance tool on cancer center adopters},
+  journal = {Cancer},
+  year    = {2025},
+  volume  = {131},
+  number  = {2},
+  pages   = {e35710},
+  doi     = {10.1002/cncr.35710},
+  note    = {PMID: 39799407. Reports 35 adopting institutions incl. 26 NCI-designated centers}
+}
+
+@article{spees2024chana,
+  author  = {Spees, Lisa P. and Baggett, Chris D. and Johnson, Katie E. and Salas, Ana I. and Morris, Hayley N. and Arsali, Emma G. and Emerson, Marc A. and Roberson, Mya L. and Olshan, Andrew F. and Wheeler, Stephanie B.},
+  title   = {Capturing Catchment Area Data Comprehensively: The {North Carolina} Cancer Health Assets and Needs Assessment ({CHANA}) Approach},
+  journal = {Preventive Oncology \& Epidemiology},
+  year    = {2024},
+  volume  = {2},
+  number  = {1},
+  doi     = {10.1080/28322134.2024.2354231},
+  note    = {PMID: 39720021}
+}
+
+@article{antonio2024deidentification,
+  author  = {Antonio, Daniel and Burus, Todd and Manning, Tarneka M. and Gurley, Michael J. and Di Salvo, Giorgio and Heneche, Jorge Andres and Passaglia, Carolyn and Kocherginsky, Masha and Simon, Melissa A.},
+  title   = {Enhancing Catchment Area Tools: A De-Identification Method for Integrating Clinical Trial Data with Cancer {InFocus}},
+  journal = {Preventive Oncology \& Epidemiology},
+  year    = {2024},
+  volume  = {2},
+  number  = {1},
+  doi     = {10.1080/28322134.2024.2388564},
+  note    = {PMID: 40027469}
+}
+
+@article{munoz2024cancerclarity,
+  author  = {Munoz, Edgar and VanHelene, Alexander D. and Yang, Nuen Tsang and Ramirez, Amelie G.},
+  title   = {{CancerClarity} App: Enhancing Cancer Data Visualization with {AI}-Generated Narratives},
+  journal = {Preventive Oncology \& Epidemiology},
+  year    = {2024},
+  volume  = {3},
+  number  = {1},
+  doi     = {10.1080/28322134.2024.2431501},
+  note    = {PMID: 40672060. Downstream consumer of Cancer InFocus data}
+}
+
+@article{lowery2026ecco,
+  author  = {Lowery, Jan T. and Alquaddoomi, Faisal and Rubinetti, Vince and Burus, Todd and Jardine, Cydney and Warren, Adam C. and Walsh, Jake and Borrayo, Evelinn and Davis, Sean},
+  title   = {Exploring Cancer in {Colorado} using a novel data platform: the {ECCO} experience},
+  journal = {medRxiv},
+  year    = {2026},
+  doi     = {10.64898/2026.02.03.26345489},
+  note    = {Preprint. PMID: 41674638. Uses Cancer InFocus and State Cancer Profiles as
+             upstream sources; self-citation — declare as such}
+}
+
+
+% =====================================================================
+% UNVERIFIED — DO NOT CITE WITHOUT CHECKING
+% =====================================================================
+%
+% The following were considered but are NOT included as live entries because a
+% verified bibliographic record was not obtained in this session:
+%
+%  - Midthune DN, Fay MP, Clegg LX, Feuer EJ, "Modeling reporting delays and
+%    reporting corrections in cancer registry data" (JASA, c. 2005). Referenced in
+%    the reporting-delay literature but not confirmed here. Verify volume/pages/DOI
+%    before use; clegg2002reportingdelay covers the same argument and IS verified.
+%  - Any NAACCR data-standards or registry-certification manual. These are cited in
+%    the field but are versioned web documents; pin a specific edition and URL with
+%    an access date rather than citing a generic entry.
+%  - State Cancer Profiles itself. It has no descriptor paper. Cite as a web
+%    resource with an access date, not as an article — see landscape-lit.md.
+%  - 10.1200/CCI.24.00099, "Interinstitutional Approach to Advancing Geospatial…"
+%    (JCO Clinical Cancer Informatics). Surfaced in catchment-area searching but
+%    NOT verified: ASCO returned 403, Ovid 402, and it is absent from PubMed.
+%    Title and DOI come from a search-result snippet only. DO NOT CITE.
+%  - Simeonov KP, Himmelstein DS (PeerJ), the elevation/lung-cancer paper behind
+%    the dhimmel/elevcan analysis repo. PMID 25648772 is confirmed to exist, but
+%    volume/pages/DOI were read off a repository README rather than an opened
+%    record. Verify before use.
+%  - Cancer InFocus source code. There is no software DOI and no public canonical
+%    repository. github.com/CIOData/CIFTools_update is the closest public code and
+%    IS included above as ciodata_ciftools, but its attribution to the Cancer
+%    InFocus team is inferred from GitHub org identity, not stated on the repo.
+%  - OSF project https://osf.io/bjzr5, "Erased at the margins: suppression bias in
+%    cancer disparities". Contributors and DOI could not be read (JS-rendered page).
+%
+% ALSO NOTE (not a citation problem, but it affects the manuscript): the Zenodo
+% sweep found live DOIs for this archive — concept 10.5281/zenodo.13174526,
+% latest version 10.5281/zenodo.18446185, and a superseded 2024 deposit
+% 10.5281/zenodo.11102940. docs/landscape.md currently says "DOI pending".
+% Reconcile before citing either way.


### PR DESCRIPTION
Manuscript scaffolding, stacked on #41 (its chunks read `data/vintages.json` and `manifests/`). Structure per the data-descriptor genre; the two working computed chunks render the vintage table and per-release integrity table; every remaining number is planned as a chunk, not prose. `MANUSCRIPT_STATE.yaml` seeds the scriptorium loop with the core claims and known weaknesses from the audit. `refs.bib` fills from the landscape literature pass (#30) when it lands.

No prose drafted yet — sections carry draft plans with the audit's claim scoping (suppression/Parquet scoped post-hardening, bracketed vintage boundaries, Kansas/Indiana caveats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)