### PR TITLE
M4: CI manifest + conditional Zenodo publish + run ledger

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -107,3 +107,37 @@ jobs:
           notes_mortality.txt
           notes_risk.txt
           notes_demographics.txt
+
+    - name: Manifest and Zenodo publish
+      env:
+        ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Same code path as the backfill (SPEC M4). Publishes a new Zenodo
+        # version only when the scrape is a new vintage; without a token it
+        # still builds the manifest but records nothing (dry-run).
+        if [ -n "$ZENODO_TOKEN" ]; then
+          uv run python scripts/zenodo/publish_release.py \
+            --release-dir . --tag "${{ steps.date.outputs.date }}"
+        else
+          echo "ZENODO_TOKEN not configured — manifest only, skipping Zenodo publish."
+          uv run python scripts/zenodo/publish_release.py \
+            --release-dir . --tag "${{ steps.date.outputs.date }}" --dry-run
+        fi
+        gh release upload "${{ steps.date.outputs.date }}" manifest.json --clobber
+
+    - name: Record run in ledger
+      run: |
+        mkdir -p ledger
+        printf '{"run":"%s","scraper_sha":"%s","workflow_run":"%s"}\n' \
+          "${{ steps.date.outputs.date }}" "${{ github.sha }}" "${{ github.run_id }}" \
+          >> ledger/runs.ndjson
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add ledger/runs.ndjson data/vintages.json
+        if git diff --cached --quiet; then
+          echo "Nothing to record."
+        else
+          git commit -m "Record run ${{ steps.date.outputs.date }}"
+          git push
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ scrape.log
 README_files
 README.html
 .coverage
-coverage.xml
+coverage.xml.env

--- a/scps/manifest.py
+++ b/scps/manifest.py
@@ -29,6 +29,24 @@ TOPICS = ("incidence", "mortality", "risk", "demographics")
 # vintage change (docs/releases.md §1.2), so they don't participate.
 VINTAGE_TOPICS = ("incidence", "mortality")
 
+# Release artifacts, by name. build_manifest and the Zenodo deposit paths
+# operate on directories that may contain other files (in CI the scrape
+# writes into the repo checkout root) — only these are release outputs.
+RELEASE_FILE_RE = re.compile(
+    r"^(state_cancer_profiles_\w+\.(csv\.gz|parquet)"
+    r"|select_options\.json|scrape_catalog\.jsonl|gh_hash\.txt"
+    r"|notes_\w+\.txt|release_note\.txt)$"
+)
+
+
+def release_files(release_dir: Path) -> list[Path]:
+    """The release artifacts present in a directory, sorted by name."""
+    return sorted(
+        p for p in release_dir.iterdir()
+        if p.is_file() and RELEASE_FILE_RE.match(p.name)
+    )
+
+
 _CREATED_RE = re.compile(
     r"Created by statecancerprofiles\.cancer\.gov on ([0-9/]+)"
 )
@@ -74,9 +92,7 @@ def build_manifest(release_dir: Path, tag: str) -> dict:
     """Manifest for one release directory (downloaded GitHub release assets)."""
     files = []
     content_hashes: dict[str, str] = {}
-    for path in sorted(release_dir.iterdir()):
-        if not path.is_file():
-            continue
+    for path in release_files(release_dir):
         entry: dict = {
             "filename": path.name,
             "sha256": sha256_file(path),

--- a/scps/zenodo.py
+++ b/scps/zenodo.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import httpx
 
+from scps.manifest import release_files
+
 logger = logging.getLogger("scps.zenodo")
 
 PRODUCTION = "https://zenodo.org"
@@ -134,7 +136,8 @@ def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-pro
     ``related_identifiers`` carries every GitHub tag that captured the
     vintage — this is also the idempotency key.
     """
-    tag_urls = [f"https://github.com/{repo}/releases/tag/release-{t}" for t in dep.tags]
+    # Git tags are bare dates ("2026-06-01"); "release-" is only in the title.
+    tag_urls = [f"https://github.com/{repo}/releases/tag/{t}" for t in dep.tags]
     description = (
         f"<p>State Cancer Profiles data extract — vintage {dep.vintage_id}. "
         f"Complete national county- and state-level extract scraped from "
@@ -170,7 +173,7 @@ def deposited_tags(versions: list[dict]) -> set[str]:
         for rel in v.get("metadata", {}).get("related_identifiers", []):
             ident = rel.get("identifier", "")
             if "/releases/tag/" in ident:
-                tags.add(ident.rsplit("/releases/tag/release-", 1)[-1])
+                tags.add(ident.rsplit("/releases/tag/", 1)[-1])
     return tags
 
 
@@ -190,7 +193,7 @@ def plan_backfill(
             logger.info("%s already deposited — skipping", vid)
             continue
         best_dir = release_root / info["best_capture"]
-        files = sorted(p for p in best_dir.iterdir() if p.is_file())
+        files = release_files(best_dir)
         plan.append(
             VintageDeposit(
                 vintage_id=vid,

--- a/scripts/zenodo/publish_release.py
+++ b/scripts/zenodo/publish_release.py
@@ -36,20 +36,45 @@ def main() -> int:
     ap.add_argument("--sandbox", action="store_true")
     ap.add_argument("--base-record", default=None)
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--assume-vintage",
+        default=None,
+        metavar="VID",
+        help=(
+            "Assign this release to an existing vintage id, overriding the "
+            "content-hash comparison. Required when the SCRAPER's output "
+            "format changed (new columns, row-filter changes): hashes then "
+            "differ even if upstream data didn't, and only a value-level "
+            "comparison on common strata (docs/releases.md §1.1) can decide. "
+            "The release's hashes are learned into the vintage so future "
+            "same-format releases compare normally."
+        ),
+    )
     args = ap.parse_args()
 
     m = manifest_mod.build_manifest(args.release_dir, args.tag)
     (args.release_dir / "manifest.json").write_text(json.dumps(m, indent=1) + "\n")
 
     vintages = manifest_mod.load_vintages(args.vintages)
-    vid, is_new = manifest_mod.assign_vintage(m, vintages)
+    if args.assume_vintage:
+        if args.assume_vintage not in vintages["vintages"]:
+            ap.error(f"--assume-vintage {args.assume_vintage} not in {args.vintages}")
+        vid, is_new = args.assume_vintage, False
+        info = vintages["vintages"][vid]
+        for topic, h in m["content_hashes"].items():
+            hashes = info["content_sha256"].setdefault(topic, [])
+            if h not in hashes:
+                hashes.append(h)
+    else:
+        vid, is_new = manifest_mod.assign_vintage(m, vintages)
     if not is_new:
         # Record the tag under its vintage so the mapping stays complete.
         info = vintages["vintages"][vid]
         if args.tag not in info["releases"]:
             info["releases"].append(args.tag)
             info["best_capture"] = args.tag
-            args.vintages.write_text(json.dumps(vintages, indent=1) + "\n")
+            if not args.dry_run:
+                args.vintages.write_text(json.dumps(vintages, indent=1) + "\n")
         logging.info("%s is vintage %s (already deposited) — nothing to publish.", args.tag, vid)
         return 0
 
@@ -68,7 +93,8 @@ def main() -> int:
         tags=[args.tag],
         publication_date=args.tag,
         best_capture=args.tag,
-        files=sorted(p for p in args.release_dir.iterdir() if p.is_file()),
+        files=manifest_mod.release_files(args.release_dir)
+        + [args.release_dir / "manifest.json"],
     )
 
     if args.sandbox:
@@ -89,6 +115,9 @@ def main() -> int:
         zenodo.run_deposit(client, str(latest), dep, dry_run=False)
     else:
         zenodo.run_deposit(zenodo.ZenodoClient(zenodo.SANDBOX, "dry"), "0", dep, dry_run=True)
+        # Dry runs record nothing: a vintages.json entry without a deposit
+        # behind it would make the next real run skip the publish.
+        return 0
 
     args.vintages.write_text(json.dumps(vintages, indent=1) + "\n")
     return 0

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -95,3 +95,20 @@ def test_assign_vintage_detects_new(tmp_path):
     vintages = _vintages("deadbeef", "deadbeef")
     vid, is_new = manifest.assign_vintage(m, vintages)
     assert (vid, is_new) == ("V2", True)
+
+
+def test_release_files_ignores_non_release_artifacts(tmp_path):
+    """In CI the release dir is the repo checkout root — only release
+    artifacts may enter the manifest or a Zenodo deposit."""
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00")
+    (rel / "README.md").write_text("repo file")
+    (rel / "pyproject.toml").write_text("[project]")
+    (rel / "manifest.json").write_text("{}")
+    names = {p.name for p in manifest.release_files(rel)}
+    assert "README.md" not in names
+    assert "pyproject.toml" not in names
+    assert "manifest.json" not in names
+    assert "state_cancer_profiles_incidence.csv.gz" in names
+    assert "gh_hash.txt" in names
+    m = manifest.build_manifest(rel, "t")
+    assert all(f["filename"] != "README.md" for f in m["files"])

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -39,7 +39,7 @@ def _version(tag: str) -> dict:
             "publication_date": "2024-08-02",
             "related_identifiers": [
                 {
-                    "identifier": f"https://github.com/seandavi/state-cancer-profile-scraper/releases/tag/release-{tag}",
+                    "identifier": f"https://github.com/seandavi/state-cancer-profile-scraper/releases/tag/{tag}",
                     "relation": "isSupplementTo",
                 }
             ],
@@ -74,8 +74,8 @@ def test_vintage_metadata_carries_identity_and_tags(tmp_path):
     assert md["license"] == "cc-by-4.0"
     assert md["upload_type"] == "dataset"
     idents = [r["identifier"] for r in md["related_identifiers"]]
-    assert any("release-2025-02-10" in i for i in idents)
-    assert any("release-2025-03-01" in i for i in idents)
+    assert any(i.endswith("/releases/tag/2025-02-10") for i in idents)
+    assert any(i.endswith("/releases/tag/2025-03-01") for i in idents)
     assert "vintage V2" in md["title"]
     # The description states the best-vs-first capture distinction.
     assert "most" in md["description"] and "first" in md["description"]


### PR DESCRIPTION
Wires SPEC M4 into run-scrape.yaml on the same code path as the backfill (closes #29). Without ZENODO_TOKEN the publish step degrades to manifest-only. Includes the release-file whitelist (CI scrapes into the checkout root — without it a deposit would have swept the whole repo), the `--assume-vintage` override for scraper-format changes, and the bare-date tag URL fix. 89 tests pass; publish step simulated locally against the real 2026-06-01 release directory salted with repo files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)