### PR TITLE
Bounded scrape concurrency: fit inside the 6-hour Actions limit

### DIFF
--- a/scps/demographics.py
+++ b/scps/demographics.py
@@ -25,6 +25,7 @@ from scps.scraper import (
     column_text_replace,
     decode_suppression,
     fetch_report,
+    parallel_fetch,
     split_report,
 )
 
@@ -287,17 +288,12 @@ def demographics_master_table(
         )
         combos = iter_demographics_combos(opts, areatypes)
 
-    dflist: list[pd.DataFrame] = []
-    for combo in combos:
-        try:
-            df = get_demographics_table(options=opts, **combo)
-            dflist.append(df)
-            if on_success is not None:
-                on_success(combo, len(df))
-        except KeyboardInterrupt:
-            raise
-        except Exception as exc:
-            logger.debug("Skipped %s: %s", combo, exc)
+    dflist = [
+        df
+        for _combo, df in parallel_fetch(
+            combos, lambda c: get_demographics_table(options=opts, **c), on_success
+        )
+    ]
 
     if not dflist:
         return pd.DataFrame()

--- a/scps/risk.py
+++ b/scps/risk.py
@@ -26,6 +26,7 @@ from scps.scraper import (
     column_text_replace,
     decode_suppression,
     fetch_report,
+    parallel_fetch,
     split_report,
 )
 
@@ -263,17 +264,12 @@ def risk_master_table(
         )
         combos = iter_risk_combos(opts, statefipses)
 
-    dflist: list[pd.DataFrame] = []
-    for combo in combos:
-        try:
-            df = get_risk_table(options=opts, **combo)
-            dflist.append(df)
-            if on_success is not None:
-                on_success(combo, len(df))
-        except KeyboardInterrupt:
-            raise
-        except Exception as exc:
-            logger.debug("Skipped %s: %s", combo, exc)
+    dflist = [
+        df
+        for _combo, df in parallel_fetch(
+            combos, lambda c: get_risk_table(options=opts, **c), on_success
+        )
+    ]
 
     if not dflist:
         return pd.DataFrame()

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -328,6 +328,40 @@ def _dedupe_death_combos(combos: Iterable[dict]) -> Iterator[dict]:
             yield combo
 
 
+def parallel_fetch(combos, fetch_one, on_success=None, workers=None):
+    """Fetch combos concurrently; yield (combo, df) in combo order.
+
+    Bounded thread-pool concurrency so a full scrape fits inside CI's
+    6-hour job limit (#45) while staying polite to the upstream site.
+    Failures come back as (combo, None) — same swallow-invalid-combos
+    semantics as the old sequential loop. Results are yielded in input
+    order and the caller invokes ``on_success`` on its own thread, so
+    catalog recording needs no locking.
+    """
+    import os
+    from concurrent.futures import ThreadPoolExecutor
+
+    if workers is None:
+        workers = int(os.environ.get("SCPS_WORKERS", "6"))
+
+    def _fetch(combo):
+        try:
+            return combo, fetch_one(combo)
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            logger.debug("Skipped %s: %s", combo, exc)
+            return combo, None
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for combo, df in pool.map(_fetch, combos):
+            if df is None:
+                continue
+            if on_success is not None:
+                on_success(combo, len(df))
+            yield combo, df
+
+
 def master_table(
     year: str = "0",
     stateFIPS: str = "00",
@@ -361,18 +395,12 @@ def master_table(
     if _type == "death":
         combos = _dedupe_death_combos(combos)
 
-    dflist = []
-    for combo in combos:
-        try:
-            df = get_table(_type=_type, **combo)
-            dflist.append(df)
-            if on_success is not None:
-                on_success(combo, len(df))
-        except KeyboardInterrupt:
-            raise
-        except Exception as e:
-            logger.debug("Caught an exception, but ignoring it")
-            logger.debug(e)
+    dflist = [
+        df
+        for _combo, df in parallel_fetch(
+            combos, lambda c: get_table(_type=_type, **c), on_success
+        )
+    ]
     # concat() drops .attrs; carry the first fetch's notes block forward so
     # the CLI can persist it (vintage string lives there — see #36).
     notes = next(

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -446,3 +446,23 @@ def test_master_table_dedupes_stage_for_death():
 
     assert len(calls) == 1
     assert "stage" not in calls[0]
+
+
+def test_parallel_fetch_preserves_order_and_swallows_failures():
+    """Concurrency must not change result order or failure semantics (#45)."""
+    def fetch(combo):
+        if combo["id"] == 2:
+            raise ValueError("invalid combo")
+        return pd.DataFrame({"x": [combo["id"]]})
+
+    successes = []
+    results = list(
+        scraper.parallel_fetch(
+            [{"id": i} for i in range(5)],
+            fetch,
+            on_success=lambda c, n: successes.append(c["id"]),
+            workers=3,
+        )
+    )
+    assert [c["id"] for c, _ in results] == [0, 1, 3, 4]
+    assert successes == [0, 1, 3, 4]


### PR DESCRIPTION
Every scrape run since 2026-06-01 — July and August scheduled runs included — was cancelled at exactly 6h, the Actions job limit; the repo has been silently missing releases since June. Root cause: the 2026-05-28 scope expansion made the sequential request loop take ~5.8h, and quarterly cartesian refreshes ~5x that. `parallel_fetch` (thread pool, default 6 workers, `SCPS_WORKERS` override) now drives all three master-table loops: deterministic result order, catalog callbacks on the caller thread (no locking), unchanged failure semantics, KeyboardInterrupt still propagates. Closes #45. 89 tests pass incl. an order/failure-semantics test for the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)