### PR TITLE
Network hardening: retry transient errors, surface silent fetch failures

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -70,10 +70,11 @@ jobs:
 
     - name: Run scrape
       env:
-        # SCP's CDN throttles GitHub-hosted-runner IPs (~10-15s/request vs
-        # ~0.3s from a normal host), so CI needs more workers than the
-        # default 6 to fit the 6-hour job limit. See #45/#47.
-        SCPS_WORKERS: "16"
+        # SCP's CDN throttles GitHub-hosted-runner IPs; 16 workers caused
+        # silent request failures (half a release's rows lost, #47), so 8
+        # is the ceiling here. The durable fix is running the scrape off
+        # GitHub-hosted runners entirely.
+        SCPS_WORKERS: "8"
       run: uv run scps-scraper scrape ${{ steps.refresh.outputs.flag }}
 
     - name: Tag with gh_hash

--- a/scps/demographics.py
+++ b/scps/demographics.py
@@ -16,12 +16,12 @@ import re
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
-import httpx
 import pandas as pd
 from bs4 import BeautifulSoup
 
 from scps.scraper import (
     NA_VALUES,
+    get_with_retry,
     column_text_replace,
     decode_suppression,
     fetch_report,
@@ -123,10 +123,10 @@ def _parse_select_options(html: str) -> dict[str, dict[str, str]]:
 
 def get_demographics_options() -> dict[str, Any]:
     """Discover demographics select options from the live website."""
-    html = httpx.get(DEMO_BASE_URL).text
+    html = get_with_retry(DEMO_BASE_URL).text
     select_opts = _parse_select_options(html)
 
-    js_text = httpx.get(DEMO_DEFINES_URL).text
+    js_text = get_with_retry(DEMO_DEFINES_URL).text
     demo_by_topic = parse_census_defines(js_text)
 
     return {

--- a/scps/risk.py
+++ b/scps/risk.py
@@ -17,12 +17,12 @@ import re
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
-import httpx
 import pandas as pd
 from bs4 import BeautifulSoup
 
 from scps.scraper import (
     NA_VALUES,
+    get_with_retry,
     column_text_replace,
     decode_suppression,
     fetch_report,
@@ -103,10 +103,10 @@ def get_risk_options() -> dict[str, Any]:
     ``statefips``, and ``datatype``. The ``risk_by_topic`` value is a nested
     ``{topic: {risk_id: label}}`` mapping parsed from ``riskJSDefines.js``.
     """
-    html = httpx.get(RISK_BASE_URL).text
+    html = get_with_retry(RISK_BASE_URL).text
     select_opts = _parse_select_options(html)
 
-    js_text = httpx.get(RISK_DEFINES_URL).text
+    js_text = get_with_retry(RISK_DEFINES_URL).text
     risk_by_topic = parse_risk_defines(js_text)
 
     return {

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -45,7 +45,7 @@ logger = logging.getLogger("scps.scraper")
 def get_select_options() -> dict:
     """Get the select options from the state cancer profiles website"""
     soup = BeautifulSoup(
-        httpx.get(
+        get_with_retry(
             "https://statecancerprofiles.cancer.gov/incidencerates/index.php"
         ).text,
         "html.parser",
@@ -109,11 +109,38 @@ NA_VALUES = ["N/A", " N/A", "N/A ", " N/A "]
 _KEY_FIELDS = {"FIPS", "HSA_Code"}
 
 
+def get_with_retry(url: str, attempts: int = 5) -> httpx.Response:
+    """GET with exponential backoff on transient network/server errors.
+
+    Long scrapes hit transient ConnectErrors and 5xx from the upstream CDN
+    (#47); one blip must not kill a multi-hour run.
+    """
+    import time
+
+    last_exc: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            resp = httpx.get(url, timeout=60.0)
+            if resp.status_code >= 500:
+                raise httpx.HTTPStatusError(
+                    f"server error {resp.status_code}", request=resp.request, response=resp
+                )
+            resp.raise_for_status()
+            return resp
+        except (httpx.TransportError, httpx.HTTPStatusError) as exc:
+            if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 500:
+                raise
+            last_exc = exc
+            wait = 2**attempt
+            logger.warning("GET %s failed (%s); retry %d/%d in %ss",
+                           url[:80], exc, attempt + 1, attempts, wait)
+            time.sleep(wait)
+    raise last_exc
+
+
 def fetch_report(url: str) -> str:
     """GET one SCP CSV export and return the raw text."""
-    resp = httpx.get(url, timeout=60.0)
-    resp.raise_for_status()
-    return resp.text
+    return get_with_retry(url).text
 
 
 def split_report(text: str) -> tuple[str, str]:
@@ -354,13 +381,24 @@ def parallel_fetch(combos, fetch_one, on_success=None, workers=None):
             logger.debug("Skipped %s: %s", combo, exc)
             return combo, None
 
+    failures = 0
+    total = 0
     with ThreadPoolExecutor(max_workers=workers) as pool:
         for combo, df in pool.map(_fetch, combos):
+            total += 1
             if df is None:
+                failures += 1
                 continue
             if on_success is not None:
                 on_success(combo, len(df))
             yield combo, df
+    if failures:
+        logger.warning(
+            "parallel_fetch: %d/%d combos returned no data "
+            "(invalid combos in discovery mode are normal; in catalog-driven "
+            "mode this is data loss and the regression check will fail).",
+            failures, total,
+        )
 
 
 def master_table(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,8 @@ MOCK_SELECT_HTML = """
 """
 
 _mock_response = MagicMock()
+
+_mock_response.status_code = 200
 _mock_response.text = MOCK_SELECT_HTML
 
 with patch("httpx.get", return_value=_mock_response):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -261,6 +261,7 @@ def test_demographics_master_table_swallows_failures():
 
 def test_get_demographics_options_combines_html_and_js():
     html_response = MagicMock()
+    html_response.status_code = 200
     html_response.text = """
     <html><body>
       <select id="topic"><option value="crowd">Crowding</option></select>
@@ -272,6 +273,7 @@ def test_get_demographics_options_combines_html_and_js():
     </body></html>
     """
     js_response = MagicMock()
+    js_response.status_code = 200
     js_response.text = SAMPLE_CENSUS_JS
 
     def fake_get(url, *_a, **_k):
@@ -279,7 +281,7 @@ def test_get_demographics_options_combines_html_and_js():
             return js_response
         return html_response
 
-    with patch("scps.demographics.httpx.get", side_effect=fake_get):
+    with patch("scps.demographics.get_with_retry", side_effect=fake_get):
         opts = demographics.get_demographics_options()
 
     assert opts["topic"] == {"crowd": "Crowding"}

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -233,6 +233,7 @@ def test_risk_master_table_propagates_keyboard_interrupt():
 
 def test_get_risk_options_combines_html_and_js():
     html_response = MagicMock()
+    html_response.status_code = 200
     html_response.text = """
     <html><body>
       <select id="topic">
@@ -253,6 +254,7 @@ def test_get_risk_options_combines_html_and_js():
     </body></html>
     """
     js_response = MagicMock()
+    js_response.status_code = 200
     js_response.text = SAMPLE_RISK_JS
 
     def fake_get(url, *_a, **_k):
@@ -260,7 +262,7 @@ def test_get_risk_options_combines_html_and_js():
             return js_response
         return html_response
 
-    with patch("scps.risk.httpx.get", side_effect=fake_get):
+    with patch("scps.risk.get_with_retry", side_effect=fake_get):
         opts = risk.get_risk_options()
 
     assert opts["topic"] == {"alcohol": "Alcohol"}

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -41,6 +41,7 @@ def test_column_text_replace_empty_string():
 
 def test_get_select_options_returns_dict():
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.text = MOCK_SELECT_HTML
     with patch("httpx.get", return_value=mock_response):
         result = scraper.get_select_options()
@@ -50,6 +51,7 @@ def test_get_select_options_returns_dict():
 
 def test_get_select_options_expected_keys():
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.text = MOCK_SELECT_HTML
     with patch("httpx.get", return_value=mock_response):
         result = scraper.get_select_options()
@@ -60,6 +62,7 @@ def test_get_select_options_expected_keys():
 
 def test_get_select_options_values_are_dicts():
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.text = MOCK_SELECT_HTML
     with patch("httpx.get", return_value=mock_response):
         result = scraper.get_select_options()
@@ -70,6 +73,7 @@ def test_get_select_options_values_are_dicts():
 
 def test_get_select_options_cancer_values():
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.text = MOCK_SELECT_HTML
     with patch("httpx.get", return_value=mock_response):
         result = scraper.get_select_options()
@@ -81,6 +85,7 @@ def test_get_select_options_cancer_values():
 def test_get_select_options_age_has_pediatric_options():
     """Age groups for pediatrics (015, 016) are added as a workaround."""
     mock_response = MagicMock()
+    mock_response.status_code = 200
     mock_response.text = MOCK_SELECT_HTML
     with patch("httpx.get", return_value=mock_response):
         result = scraper.get_select_options()


### PR DESCRIPTION
Follow-up to #47 from run 32689569271: parquet fix confirmed working; new failure was an unretried ConnectError in the demographics options fetch, plus silent request failures at 16 workers that halved the incidence row count. `get_with_retry` (exponential backoff on transport errors/5xx) now backs every upstream GET; `parallel_fetch` reports a failure count per endpoint; CI workers capped at 8. 91 tests pass.

The durable fix remains moving the scrape off GitHub-hosted runners (SCP's CDN throttles them ~50x); local timing suggests ~20 minutes on onclappc02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)