### PR TITLE
Adapt to upstream defines refactor (renamed + reformatted JS)

### DIFF
--- a/scps/demographics.py
+++ b/scps/demographics.py
@@ -21,7 +21,9 @@ from bs4 import BeautifulSoup
 
 from scps.scraper import (
     NA_VALUES,
+    find_defines_url,
     get_with_retry,
+    parse_defines,
     column_text_replace,
     decode_suppression,
     fetch_report,
@@ -32,73 +34,18 @@ from scps.scraper import (
 logger = logging.getLogger("scps.demographics")
 
 DEMO_BASE_URL = "https://statecancerprofiles.cancer.gov/demographics/index.php"
-DEMO_DEFINES_URL = (
-    "https://statecancerprofiles.cancer.gov/demographics/censusJSDefines.js"
-)
 
 _PLACEHOLDER_VALUES = {"*", "**", "***", "****", "*****"}
 
-# Matches lines like:  ed_array['00004']="Less than 9th grade";
-#                       population_ages_array['00002'] = "Ages under 18";
-# Backreferenced quotes (\2 and \4) so apostrophes inside double-quoted
-# labels (e.g. "bachelor's degree") aren't treated as terminators.
-_DEMO_LINE_RE = re.compile(
-    r"""^\s*(?P<array>[a-z_]+_array)\[(['"])(?P<id>[^'"]+)\2\]\s*=\s*"""
-    r"""(['"])(?P<label>.*?)\4\s*;""",
-    re.MULTILINE,
-)
-
-
-# Matches /* ... */ block comments (non-greedy, multi-line).
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-
-# Arrays in the JS file that look like topic definitions but aren't —
-# they're the picker-label lookups, not demo-id mappings.
-_NON_TOPIC_ARRAYS = {"topic_box"}
-
 
 def parse_census_defines(js_text: str) -> dict[str, dict[str, str]]:
-    """Parse ``censusJSDefines.js`` into ``{topic: {demo_id: label}}``.
+    """Parse the demographics defines script into ``{topic: {demo_id: label}}``.
 
-    The ``pop`` topic is a special case: its ids live in two sibling arrays
-    (``population_ages_array``, ``population_races_array``) that are
-    re-exported by ``pop_array['Ages']`` / ``pop_array['Races']`` at runtime.
-    We merge both into the ``pop`` mapping here.
+    2026-08 upstream format: ``const demo_topic_<t> = [["id", "label"], ...]``.
+    The old dual population arrays are now a single upstream ``demo_topic_pop``
+    with OPTION_GROUP_START markers, which the parser skips.
     """
-    # Strip block comments first so commented-out array definitions
-    # (e.g. ur_array) don't get parsed as live topics.
-    js_text = _BLOCK_COMMENT_RE.sub("", js_text)
-
-    flat: dict[str, dict[str, str]] = {}
-    for raw_line in js_text.splitlines():
-        if raw_line.lstrip().startswith("//"):
-            continue
-        match = _DEMO_LINE_RE.match(raw_line)
-        if not match:
-            continue
-        array = match.group("array")
-        demo_id = match.group("id")
-        if demo_id in _PLACEHOLDER_VALUES:
-            continue
-        flat.setdefault(array, {})[demo_id] = match.group("label")
-
-    result: dict[str, dict[str, str]] = {}
-    for array_name, mapping in flat.items():
-        if not array_name.endswith("_array"):
-            continue
-        topic = array_name[: -len("_array")]
-        if topic.startswith("population_") or topic in _NON_TOPIC_ARRAYS:
-            # Folded into pop_array below, or not a real topic.
-            continue
-        result[topic] = dict(mapping)
-
-    pop_merged: dict[str, str] = {}
-    pop_merged.update(flat.get("population_ages_array", {}))
-    pop_merged.update(flat.get("population_races_array", {}))
-    if pop_merged:
-        result["pop"] = pop_merged
-
-    return result
+    return parse_defines(js_text, "demo_topic_")
 
 
 def _parse_select_options(html: str) -> dict[str, dict[str, str]]:
@@ -126,7 +73,7 @@ def get_demographics_options() -> dict[str, Any]:
     html = get_with_retry(DEMO_BASE_URL).text
     select_opts = _parse_select_options(html)
 
-    js_text = get_with_retry(DEMO_DEFINES_URL).text
+    js_text = get_with_retry(find_defines_url(html)).text
     demo_by_topic = parse_census_defines(js_text)
 
     return {

--- a/scps/risk.py
+++ b/scps/risk.py
@@ -22,7 +22,9 @@ from bs4 import BeautifulSoup
 
 from scps.scraper import (
     NA_VALUES,
+    find_defines_url,
     get_with_retry,
+    parse_defines,
     column_text_replace,
     decode_suppression,
     fetch_report,
@@ -33,47 +35,18 @@ from scps.scraper import (
 logger = logging.getLogger("scps.risk")
 
 RISK_BASE_URL = "https://statecancerprofiles.cancer.gov/risk/index.php"
-RISK_DEFINES_URL = "https://statecancerprofiles.cancer.gov/risk/riskJSDefines.js"
 
 # These placeholder values appear in the HTML selects as "--- choose X ---"
 # prompts and should never be used as real query parameters.
 _PLACEHOLDER_VALUES = {"*", "**", "***", "****", "*****"}
 
-# Matches lines like:  alcohol_array['v505']="Binge drinking ...";
-# Captures the topic, risk id, and label. Backreferences (\2 and \4) ensure
-# the closing quote matches the opening one, so apostrophes inside a
-# double-quoted label (e.g. "Men's Health") aren't treated as terminators.
-_RISK_LINE_RE = re.compile(
-    r"""^\s*(?P<topic>[a-z]+)_array\[(['"])(?P<risk>[^'"]+)\2\]\s*=\s*"""
-    r"""(['"])(?P<label>.*?)\4\s*;""",
-    re.MULTILINE,
-)
-
-
-# Matches /* ... */ block comments (non-greedy, multi-line).
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-
 
 def parse_risk_defines(js_text: str) -> dict[str, dict[str, str]]:
-    """Parse ``riskJSDefines.js`` into ``{topic: {risk_id: label}}``.
+    """Parse the risk defines script into ``{topic: {risk_id: label}}``.
 
-    Both ``//`` line comments and ``/* ... */`` block comments are skipped,
-    and the placeholder ``'**'`` "choose risk factor" entry is excluded.
+    2026-08 upstream format: ``const risk_<topic> = [["id", "label"], ...]``.
     """
-    js_text = _BLOCK_COMMENT_RE.sub("", js_text)
-    result: dict[str, dict[str, str]] = {}
-    for raw_line in js_text.splitlines():
-        if raw_line.lstrip().startswith("//"):
-            continue
-        match = _RISK_LINE_RE.match(raw_line)
-        if not match:
-            continue
-        topic = match.group("topic")
-        risk = match.group("risk")
-        if risk in _PLACEHOLDER_VALUES:
-            continue
-        result.setdefault(topic, {})[risk] = match.group("label")
-    return result
+    return parse_defines(js_text, "risk_")
 
 
 def _parse_select_options(html: str) -> dict[str, dict[str, str]]:
@@ -106,7 +79,7 @@ def get_risk_options() -> dict[str, Any]:
     html = get_with_retry(RISK_BASE_URL).text
     select_opts = _parse_select_options(html)
 
-    js_text = get_with_retry(RISK_DEFINES_URL).text
+    js_text = get_with_retry(find_defines_url(html)).text
     risk_by_topic = parse_risk_defines(js_text)
 
     return {

--- a/scps/scraper.py
+++ b/scps/scraper.py
@@ -28,6 +28,7 @@ options are not valid for some of the other options.
 
 import csv
 import functools
+import re
 import io
 from collections.abc import Callable, Iterable, Iterator
 
@@ -107,6 +108,47 @@ NA_VALUES = ["N/A", " N/A", "N/A ", " N/A "]
 # Every SCP export names its area-code column one of these; the header line
 # is located by content, not by a fixed offset (#36).
 _KEY_FIELDS = {"FIPS", "HSA_Code"}
+
+
+_DEFINES_SRC_RE = re.compile(r'src="([^"]*[Dd]efines\.js[^"]*)"')
+_CONST_BLOCK_RE = re.compile(r"const\s+(\w+)\s*=\s*\[(.*?)\];", re.S)
+_PAIR_RE = re.compile(r'\[\s*"([^"]+)"\s*,\s*"([^"]*)"\s*\]')
+
+SCP_HOST = "https://statecancerprofiles.cancer.gov"
+
+
+def find_defines_url(html: str, host: str = SCP_HOST) -> str:
+    """Locate the topic-defines script referenced by a page.
+
+    Upstream renamed riskJSDefines.js -> /j/riskDefines.js (and the
+    demographics equivalent) in a 2026-08 front-end refresh; discovering
+    the URL from the page's own script tag survives the next rename.
+    """
+    m = _DEFINES_SRC_RE.search(html)
+    if m is None:
+        raise ValueError("no *Defines.js script tag found in page")
+    src = m.group(1)
+    return src if src.startswith("http") else host + src
+
+
+def parse_defines(js_text: str, prefix: str) -> dict[str, dict[str, str]]:
+    """Parse 2026-08-format defines: ``const <prefix><topic> = [["id","label"], ...]``.
+
+    Unquoted first elements (OPTION_GROUP_START markers) and ``*_arrays``
+    lookup tables are skipped; ``//`` line comments are ignored.
+    """
+    js_text = "\n".join(
+        line for line in js_text.splitlines()
+        if not line.lstrip().startswith("//")
+    )
+    out: dict[str, dict[str, str]] = {}
+    for name, body in _CONST_BLOCK_RE.findall(js_text):
+        if not name.startswith(prefix) or name.endswith("_arrays"):
+            continue
+        entries = {i: label for i, label in _PAIR_RE.findall(body)}
+        if entries:
+            out[name[len(prefix):]] = entries
+    return out
 
 
 def get_with_retry(url: str, attempts: int = 5) -> httpx.Response:

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -13,80 +13,53 @@ from scps import demographics
 # ---------------------------------------------------------------------------
 
 SAMPLE_CENSUS_JS = """
-var population_ages_array = new Array();
-population_ages_array['00002'] = "Ages under 18";
-population_ages_array['00003'] = "Ages 65 and over";
+// 2026-08 upstream format.
+const demo_topic_crowd = [
+  ["00027", "Households with >1 person per room"],
+];
 
-var population_races_array = new Array();
-population_races_array['00014'] = "Foreign born";
-population_races_array['00022'] = "Black";
+const demo_topic_ed = [
+  ["00004", "Less than 9th grade"],
+];
 
-var pop_array = new Array();
-pop_array['Ages'] = population_ages_array;
-pop_array['Races'] = population_races_array;
+const demo_topic_pop = [
+  [OPTION_GROUP_START, "Ages"],
+  ["00002", "Ages under 18"],
+  [OPTION_GROUP_START, "Races"],
+  ["00058", "Foreign born"],
+];
 
-var ed_array = new Array();
-ed_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
-ed_array['00004']="Less than 9th grade";
-//ed_array['00005']="Less than high school";
-ed_array['00006']="At least bachelor's degree";
+const demo_topic_arrays = {
+  crowd: demo_topic_crowd,
+  ed: demo_topic_ed,
+  pop: demo_topic_pop,
+};
 
-var crowd_array = new Array();
-crowd_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
-crowd_array['00027']="Households with >1 person per room";
+const age_all = [
+  ["001", "All Ages"],
+];
 """
 
 
 def test_parse_census_defines_returns_topic_to_demo_mapping():
     result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
-    assert result["ed"] == {
-        "00004": "Less than 9th grade",
-        "00006": "At least bachelor's degree",
-    }
     assert result["crowd"] == {"00027": "Households with >1 person per room"}
+    assert result["ed"] == {"00004": "Less than 9th grade"}
 
 
-def test_parse_census_defines_merges_population_subarrays_into_pop():
-    """pop_array re-exports population_ages_array + population_races_array."""
+def test_parse_census_defines_pop_skips_group_markers():
+    """OPTION_GROUP_START pseudo-entries (unquoted ids) are not demo ids."""
     result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
     assert result["pop"] == {
         "00002": "Ages under 18",
-        "00003": "Ages 65 and over",
-        "00014": "Foreign born",
-        "00022": "Black",
+        "00058": "Foreign born",
     }
 
 
-def test_parse_census_defines_skips_comments_and_placeholders():
+def test_parse_census_defines_ignores_non_topic_consts():
     result = demographics.parse_census_defines(SAMPLE_CENSUS_JS)
-    # Commented "00005" line excluded.
-    assert "00005" not in result.get("ed", {})
-    # Placeholder "*****" excluded.
-    assert "*****" not in result.get("ed", {})
-
-
-def test_parse_census_defines_skips_block_commented_arrays():
-    """The live JS has `var ur_array = ...` inside /* ... */; must be skipped."""
-    js_with_block_comment = SAMPLE_CENSUS_JS + """
-/*
-var ur_array = new Array();
-ur_array['*****']=CHOOSE_BEGINNING + "choose demographic variable" + CHOOSE_END;
-ur_array['00001']="Continuum Code";
-*/
-"""
-    result = demographics.parse_census_defines(js_with_block_comment)
-    assert "ur" not in result
-
-
-def test_parse_census_defines_excludes_topic_box_array():
-    """`topic_box_array` is the topic-label lookup, not a topic definition."""
-    js_with_topic_box = SAMPLE_CENSUS_JS + """
-var topic_box_array = new Array();
-topic_box_array["crowd"] = "Crowding";
-topic_box_array["ed"] = "Education";
-"""
-    result = demographics.parse_census_defines(js_with_topic_box)
-    assert "topic_box" not in result
+    # The *_arrays lookup table and unrelated consts (age_all) are excluded.
+    assert set(result) == {"crowd", "ed", "pop"}
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +236,7 @@ def test_get_demographics_options_combines_html_and_js():
     html_response = MagicMock()
     html_response.status_code = 200
     html_response.text = """
-    <html><body>
+    <html><head><script src="/j/demographicsDefines.js"></script></head><body>
       <select id="topic"><option value="crowd">Crowding</option></select>
       <select id="areatype"><option value="county">By County</option></select>
       <select id="race"><option value="00">All Races</option></select>

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -13,19 +13,25 @@ from scps import risk
 # ---------------------------------------------------------------------------
 
 SAMPLE_RISK_JS = """
-var alcohol_array = new Array();
-alcohol_array['**']=CHOOSE_BEGINNING + "choose screening or risk factor" + CHOOSE_END;
-alcohol_array['v505']="Binge drinking, ages 21+";
-//alcohol_array['v501']="Mean number of alcoholic drinks per day, ages 21+";
+// For the risk listboxes (2026-08 upstream format).
+const risk_alcohol = [
+  ["v505", "Binge drinking, ages 21+"],
+];
+// const risk_old = [["v999", "Removed topic"]];
 
-var smoke_array = new Array();
-smoke_array['**']=CHOOSE_BEGINNING + "choose screening or risk factor" + CHOOSE_END;
-smoke_array["v19"]="Current Smoking; Ages 18+";
-smoke_array["v28"]="Smokers (Ever); Ages 18+";
+const risk_smoke = [
+  ["v19", "Current Smoking; Ages 18+"], // biased; note kept inline
+  ["v28", "Smokers (Ever); Ages 18+"],
+];
 
-var topic_arrays = new Array();
-topic_arrays["alcohol"] = alcohol_array;
-topic_arrays["smoke"] = smoke_array;
+const topic_arrays = {
+  alcohol: risk_alcohol,
+  smoke: risk_smoke,
+};
+
+const comparison_selection_race = [
+  ["race_00", "All Races (includes Hispanic)"],
+];
 """
 
 
@@ -40,16 +46,16 @@ def test_parse_risk_defines_returns_topic_to_risk_mapping():
     }
 
 
-def test_parse_risk_defines_skips_commented_lines():
+def test_parse_risk_defines_skips_commented_out_blocks():
     result = risk.parse_risk_defines(SAMPLE_RISK_JS)
-    # v501 is commented out and must not appear.
-    assert "v501" not in result.get("alcohol", {})
+    assert "old" not in result
+    assert all("v999" not in ids for ids in result.values())
 
 
-def test_parse_risk_defines_skips_placeholder_choice_entries():
+def test_parse_risk_defines_ignores_non_risk_consts():
+    # topic_arrays lookup table and unrelated consts must not become topics.
     result = risk.parse_risk_defines(SAMPLE_RISK_JS)
-    assert "**" not in result.get("alcohol", {})
-    assert "**" not in result.get("smoke", {})
+    assert set(result) == {"alcohol", "smoke"}
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +241,7 @@ def test_get_risk_options_combines_html_and_js():
     html_response = MagicMock()
     html_response.status_code = 200
     html_response.text = """
-    <html><body>
+    <html><head><script src="/j/riskDefines.js"></script></head><body>
       <select id="topic">
         <option value="alcohol">Alcohol</option>
       </select>


### PR DESCRIPTION
SCP shipped a front-end refresh mid-scrape: the hardcoded riskJSDefines.js/censusJSDefines.js are 404 (renamed to /j/riskDefines.js and /j/demographicsDefines.js) and the format changed from `topic_array['id']="label"` assignments to ES6 `const risk_<topic> = [[id, label], ...]` blocks. Fix follows the repo's own content-over-position rule: the defines URL is discovered from the page's script tag, and a shared parser handles the new format (validated against the live files: 7 risk topics, 11 demographics topics incl. the upstream-merged pop). Data endpoints and selects are unchanged — verified live. 89 tests pass.

Bonus observation while verifying: risk now serves 2024 BRFSS and demographics 2020-2024 ACS — upstream data refreshed alongside the front end, so the imminent release likely captures a live vintage transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)