### PR TITLE
Manifest: parquet row counts from file metadata

### DIFF
--- a/scps/manifest.py
+++ b/scps/manifest.py
@@ -107,7 +107,9 @@ def build_manifest(release_dir: Path, tag: str) -> dict:
             entry.update(format="csv.gz", topic=topic, rows=rows, content_sha256=chash)
             content_hashes[topic] = chash
         elif path.suffix == ".parquet":
-            entry.update(format="parquet", rows=len(pd.read_parquet(path, columns=[])))
+            import pyarrow.parquet as pq
+
+            entry.update(format="parquet", rows=pq.ParquetFile(path).metadata.num_rows)
         notes_match = re.fullmatch(r"notes_(\w+)\.txt", path.name)
         if notes_match:
             entry["notes"] = extract_notes_fields(path.read_text())

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -112,3 +112,13 @@ def test_release_files_ignores_non_release_artifacts(tmp_path):
     assert "gh_hash.txt" in names
     m = manifest.build_manifest(rel, "t")
     assert all(f["filename"] != "README.md" for f in m["files"])
+
+
+def test_parquet_row_count_uses_metadata(tmp_path):
+    """len(read_parquet(columns=[])) returns 0; metadata.num_rows is right."""
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00")
+    df = pd.DataFrame({"fips": ["01001", "01003", "01005"]})
+    df.to_parquet(rel / "state_cancer_profiles_incidence.parquet", index=False)
+    m = manifest.build_manifest(rel, "t")
+    pq_entry = next(f for f in m["files"] if f["filename"].endswith(".parquet"))
+    assert pq_entry["rows"] == 3


### PR DESCRIPTION
The zero-column read returns an empty index, so every parquet asset in the first release manifest carried rows=0. metadata.num_rows is exact and free. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)