### PR TITLE
Record release 2026-08-24 (vintage V3, first hardened capture)

### DIFF
--- a/data/vintages.json
+++ b/data/vintages.json
@@ -56,19 +56,28 @@
     "2026-05-01",
     "2026-05-27",
     "2026-05-28",
-    "2026-06-01"
+    "2026-06-01",
+    "2026-08-24"
    ],
    "first_capture": "2026-04-01",
-   "best_capture": "2026-06-01",
+   "best_capture": "2026-08-24",
    "defective_releases": [],
    "content_sha256": {
     "incidence": [
      "5e7f9f50ef76c51e74770061a176667f217757716b66e142cc5fed46e032ef32",
-     "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa"
+     "db2b0672dfdfc87e263efd89da269d667a725060f430a8986f63aa341545e5fa",
+     "a120cd6e0f73279460dd4d82dc5152b3afd6e3386cd9c4b194fb50ab9efdee34"
     ],
     "mortality": [
      "2ecc04fa1975b0d06d66f8c88ad1d1063fb016b7cce4b25ea68120d11f6aa398",
-     "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c"
+     "ec50eace83b001b12332da62e7c538039485789a90e30da0ceabe6717f5d4f4c",
+     "16f9f39707390bbb5103ec646a127029e8c93a3e1dc8cdaff5f8c0d703f91993"
+    ],
+    "demographics": [
+     "5b37483e2c2a8328d5f7e31a63898ba04bec1c691a2a4ab9de5591f71aa7d2bc"
+    ],
+    "risk": [
+     "6a370ab842e9d52d2191c11ad7e79331cfcdcf511bda29a9570b78d80095574b"
     ]
    }
   }

--- a/ledger/runs.ndjson
+++ b/ledger/runs.ndjson
@@ -1,0 +1,1 @@
+{"run":"2026-08-24","scraper_sha":"362abfd5a44ca8b396c3a561e15c1db07f2bf6c1","workflow_run":"local (see #47)"}


### PR DESCRIPTION
Bookkeeping for the just-published release-2026-08-24: tag added to V3 in data/vintages.json with its content hashes learned (vintage assigned by value-level comparison — 0 of 1,993,874 common incidence+mortality cells changed vs 2026-06-01 — since the output format changed and hashes can't decide); best capture updated; run ledger entry added.

Release facts: incidence 11,048,853 rows (vs 1.48M in June — retained suppressed cells; ~87% of the county matrix is suppressed), mortality 5,866,632 (deduped), risk 78,798 (2024 BRFSS — upstream refreshed), demographics 3,281,295 (2020-2024 ACS; leaked-note rows now excluded at source). All 15,180 catalog combos verified fetched; parquet row counts match CSVs exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)