### PR TITLE
Zenodo: full-record fetch for reused drafts

### DIFF
--- a/scps/zenodo.py
+++ b/scps/zenodo.py
@@ -119,7 +119,10 @@ class ZenodoClient:
             for d in drafts:
                 if d.get("conceptrecid") == concept:
                     logger.info("Reusing existing draft %s", d["id"])
-                    return d
+                    # List items lack links.bucket — fetch the full record.
+                    return self._request(
+                        "GET", f"/api/deposit/depositions/{d['id']}"
+                    ).json()
             raise
         draft_url = resp["links"]["latest_draft"]
         return self._request("GET", draft_url).json()


### PR DESCRIPTION
The draft-reuse fallback returned an item from the depositions list, which omits links.bucket, so the V3 rerun crashed at upload. Fetch the draft's full record by id before returning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)