### PR TITLE
Topic-edition policy: vintages keyed on incidence+mortality, documented everywhere

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,6 +8,12 @@
 > scrapes that captured identical values belong to one vintage. The term follows the
 > "real-time data" literature in economics, where a vintage is a statistical series as it
 > existed on a given date (Croushore & Stark).
+>
+> Vintage identity is keyed on the **registry-observed incidence and mortality** estimates
+> only. The screening/risk-factor and demographics topics are modelled or survey products
+> (BRFSS small-area estimates; ACS) that refresh on their own cadence; a vintage's Zenodo
+> deposit carries the newest topic edition captured during the vintage, and earlier
+> within-vintage editions remain in the GitHub releases, hash-verified via `manifests/`.
 
 Covers SPEC Task 0 items 1, 2 (and item 4/5 live in `schema-drift.md` / `coverage-drift.md`).
 Audit performed 2026-08-23 against `seandavi/state-cancer-profile-scraper`. All 19 releases

--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -139,7 +139,11 @@ for r in rows:
 - Risk/screening estimates are MODELLED small-area estimates
   (raghunathan2007combining, liu2019smallarea), not registry-observed —
   different epistemic status from incidence/mortality; they can change
-  between vintages because the model was refit.
+  between vintages because the model was refit. Vintage identity is keyed
+  on incidence+mortality only; risk/demographics editions refresh on
+  their own cadence, the Zenodo deposit carries the newest edition per
+  vintage, and earlier within-vintage editions live in the GitHub
+  releases (hash-verified).
 - Trend columns are Joinpoint outputs whose software defaults have
   changed over time (kim2022twentyyears): do not compare AAPC across
   vintages without checking the producing version.

--- a/scps/zenodo.py
+++ b/scps/zenodo.py
@@ -194,6 +194,7 @@ def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-pro
         f"is not necessarily the first; the publication date reflects first "
         f"capture. Vintage grouping method and release-level provenance: "
         f"https://github.com/{repo}/blob/main/docs/releases.md</p>"
+        + _topics_paragraph(dep)
     )
     return {
         "title": f"United States State Cancer Profiles data extract — vintage {dep.vintage_id}",
@@ -208,6 +209,30 @@ def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-pro
             for u in tag_urls
         ],
     }
+
+
+def _topics_paragraph(dep: VintageDeposit) -> str:
+    """State which topics the deposit carries and how topic editions relate
+    to vintage identity (which is keyed on incidence+mortality only)."""
+    has_all_topics = any("risk" in f.name for f in dep.files)
+    if not has_all_topics:
+        return (
+            "<p><b>Topics:</b> this vintage predates collection of the "
+            "screening/risk-factor and demographics topics (added to the "
+            "scraper on 2026-05-28); it contains incidence and mortality "
+            "only.</p>"
+        )
+    return (
+        "<p><b>Topics and editions:</b> vintage identity is keyed on the "
+        "registry-observed incidence and mortality estimates. The "
+        "screening/risk-factor and demographics topics are modelled or "
+        "survey products (BRFSS small-area estimates; American Community "
+        "Survey) that refresh on their own cadence; this deposit carries "
+        "the newest edition of those topics captured during the vintage. "
+        "Any earlier within-vintage editions remain available, "
+        "byte-identical and hash-verified, in the GitHub releases listed "
+        "above.</p>"
+    )
 
 
 def deposited_tags(versions: list[dict]) -> set[str]:


### PR DESCRIPTION
Sean's option 1 for the risk/demographics question: keep the vintage model keyed on the registry-observed core and document topic editions instead of redesigning. Zenodo descriptions become topic-aware (V1/V2: 'predates collection'; V3+: newest-edition-per-vintage with earlier editions in the GitHub releases, hash-verified); docs/releases.md and the manuscript Usage Notes plan carry the same statement. Applied to published versions via refresh_metadata.py after V3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)