### PR TITLE
Record the published vintage DOIs

### DIFF
--- a/data/vintages.json
+++ b/data/vintages.json
@@ -15,7 +15,8 @@
     "mortality": [
      "1f40af102eb84043a0eab51b77c1a95c277012864308b95f37f729ac1488496e"
     ]
-   }
+   },
+   "doi": "10.5281/zenodo.12685787"
   },
   "V2": {
    "releases": [
@@ -48,7 +49,8 @@
      "7e766d8f9630c641b56d22761e24f804c7d1f9adb5dc1f5b787c660588ef8931",
      "342cb495c3f13d88617bf4b68ad84d50c9a2a812eba493d03aa59169e55ce274"
     ]
-   }
+   },
+   "doi": "10.5281/zenodo.22085047"
   },
   "V3": {
    "releases": [
@@ -79,8 +81,10 @@
     "risk": [
      "6a370ab842e9d52d2191c11ad7e79331cfcdcf511bda29a9570b78d80095574b"
     ]
-   }
+   },
+   "doi": "10.5281/zenodo.22085273"
   }
  },
- "definition": "A vintage is one edition of the upstream estimates: the complete set of values statecancerprofiles.cancer.gov served during some period, bounded by NCI silently replacing them with revised values. Several releases that captured identical values belong to one vintage."
+ "definition": "A vintage is one edition of the upstream estimates: the complete set of values statecancerprofiles.cancer.gov served during some period, bounded by NCI silently replacing them with revised values. Several releases that captured identical values belong to one vintage.",
+ "concept_doi": "10.5281/zenodo.11098814"
 }

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -112,9 +112,10 @@ is not a mortality dimension — see the duplication defect in `docs/wayback-ass
 
 ## 7. Credentials
 
-No Zenodo API token found in the environment, `~/.config`, or GSM. **Needed from Sean:**
-a production token (`deposit:write` + `deposit:actions`) and a sandbox.zenodo.org token.
-The webhook's existence confirms the Zenodo account link is healthy.
+Resolved 2026-08-24: production token supplied via `.env` (rotate after the backfill —
+an early traceback exposed it before the Bearer-header fix); sandbox rehearsal consciously
+skipped on Sean's direction in favour of a direct production run with draft-based
+recovery. Backfill complete — see `docs/releases.md` §1.5 for the DOIs.
 
 ## 10. Distribution endpoints — tested 2026-08-23
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -128,6 +128,13 @@ plus the content hash, not a parsed upstream date.
 
 ### 1.5 Consequences for M3 (Zenodo backfill)
 
+**Deposited 2026-08-24** on concept DOI 10.5281/zenodo.11098814: V1 →
+10.5281/zenodo.12685787, V2 → 10.5281/zenodo.22085047, V3 → 10.5281/zenodo.22085273
+(best capture `2026-08-24`; 16 files byte-identity verified against `manifests/`). The
+open questions below were resolved as recommended: best-capture bytes, first-capture
+publication dates.
+
+
 - Three version DOIs, not nineteen. Concept DOI + V1/V2/V3.
 - `related_identifiers` per version lists the tags in §1.1 — 1, 13, and 5 tags respectively.
 - `publication_date` per SPEC = first capture: 2024-08-02, 2025-02-10, 2026-04-01.

--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -79,10 +79,10 @@ differentiates. Honest vintage count (3, prospective record). -->
 #| output: asis
 import json, pathlib
 v = json.loads(pathlib.Path("../data/vintages.json").read_text())["vintages"]
-print("| Vintage | Releases | First captured | Best capture |")
-print("|---|---|---|---|")
+print("| Vintage | DOI | Releases | First captured | Best capture |")
+print("|---|---|---|---|---|")
 for vid, info in sorted(v.items()):
-    print(f"| {vid} | {len(info['releases'])} | {info['first_capture']} | {info['best_capture']} |")
+    print(f"| {vid} | {info.get('doi', 'pending')} | {len(info['releases'])} | {info['first_capture']} | {info['best_capture']} |")
 ```
 
 <!-- Per-vintage DOI table once the backfill has run; file inventory from


### PR DESCRIPTION
Bookkeeping for the completed backfill: DOIs into data/vintages.json (the manuscript's vintage-table chunk now renders them — computed, never typed), docs/releases.md §1.5 updated with the deposit record, docs/audit.md item 7 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)