### PR TITLE
00_README.txt: NLM-style deposit documentation

### DIFF
--- a/.github/workflows/run-scrape.yaml
+++ b/.github/workflows/run-scrape.yaml
@@ -130,7 +130,7 @@ jobs:
           uv run python scripts/zenodo/publish_release.py \
             --release-dir . --tag "${{ steps.date.outputs.date }}" --dry-run
         fi
-        gh release upload "${{ steps.date.outputs.date }}" manifest.json --clobber
+        gh release upload "${{ steps.date.outputs.date }}" manifest.json 00_README.txt --clobber
 
     - name: Record run in ledger
       run: |

--- a/manifests/2026-08-24.json
+++ b/manifests/2026-08-24.json
@@ -1,0 +1,133 @@
+{
+ "tag": "2026-08-24",
+ "files": [
+  {
+   "filename": "gh_hash.txt",
+   "sha256": "96e47c2d960876456675f0e06c00e80d5a10c46bad2c7e2b05b1cc86b61989b1",
+   "bytes": 41
+  },
+  {
+   "filename": "notes_demographics.txt",
+   "sha256": "64ac61709d93ce5e35f95ccbca4d009556b7a42d9af2f1e8e9ba140118931af2",
+   "bytes": 1462,
+   "notes": {
+    "created_on": "08/24/2026",
+    "submission_years": []
+   }
+  },
+  {
+   "filename": "notes_incidence.txt",
+   "sha256": "dd30ca5b482210716ef8d3134f86551e561d8b5fc21284800ed958320c134460",
+   "bytes": 4654,
+   "notes": {
+    "created_on": "08/24/2026",
+    "submission_years": [
+     "2024"
+    ]
+   }
+  },
+  {
+   "filename": "notes_mortality.txt",
+   "sha256": "fcd4ce55683e29250ccb49238029f029bcd06f500127f0c8189530a57824132e",
+   "bytes": 3354,
+   "notes": {
+    "created_on": "08/24/2026",
+    "submission_years": []
+   }
+  },
+  {
+   "filename": "notes_risk.txt",
+   "sha256": "90a5b6a24d4a43f93d3a671c62e8409e80aaa636aa52ef8dcf643214eff8de2c",
+   "bytes": 1143,
+   "notes": {
+    "created_on": "08/24/2026",
+    "submission_years": []
+   }
+  },
+  {
+   "filename": "release_note.txt",
+   "sha256": "3c299aec1ee9c0c95717e849016ea237b6263c00e2d4d45a13a61c58045a051d",
+   "bytes": 96
+  },
+  {
+   "filename": "scrape_catalog.jsonl",
+   "sha256": "6e50625ff0ea186e91bc2bee299d97e35ea084f968d5a03ef3bbe0a584f781ba",
+   "bytes": 3427523
+  },
+  {
+   "filename": "select_options.json",
+   "sha256": "51a23a754a2d4f2eb05e78a846d7f7c34c1f1266877867797213a04e69b502e2",
+   "bytes": 3765
+  },
+  {
+   "filename": "state_cancer_profiles_demographics.csv.gz",
+   "sha256": "cb0766fb7d12700e5ea28a7bea9a3f99a9075d530bb4fd831126e81b0ef9e78f",
+   "bytes": 60966925,
+   "format": "csv.gz",
+   "topic": "demographics",
+   "rows": 3281295,
+   "content_sha256": "5b37483e2c2a8328d5f7e31a63898ba04bec1c691a2a4ab9de5591f71aa7d2bc"
+  },
+  {
+   "filename": "state_cancer_profiles_demographics.parquet",
+   "sha256": "f38e187a2479a82ba0013c0609bcf2f92b3fa019312589bc32af2d55bbfd95c6",
+   "bytes": 17508453,
+   "format": "parquet",
+   "rows": 3281295
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.csv.gz",
+   "sha256": "db19dd080289c358946e82a9a8d16dfe7a392330f9c1ec8ff4ce31c45133cacd",
+   "bytes": 212641957,
+   "format": "csv.gz",
+   "topic": "incidence",
+   "rows": 11048853,
+   "content_sha256": "a120cd6e0f73279460dd4d82dc5152b3afd6e3386cd9c4b194fb50ab9efdee34"
+  },
+  {
+   "filename": "state_cancer_profiles_incidence.parquet",
+   "sha256": "66aa8a7b7101343b6df711543d2b10e70ecae3227594d84d4f907b2e56603585",
+   "bytes": 75844731,
+   "format": "parquet",
+   "rows": 11048853
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.csv.gz",
+   "sha256": "56d771100d8ef48b0282336847b905a0dc43e6c8e06641c580578d4bb39aa391",
+   "bytes": 107484131,
+   "format": "csv.gz",
+   "topic": "mortality",
+   "rows": 5866632,
+   "content_sha256": "16f9f39707390bbb5103ec646a127029e8c93a3e1dc8cdaff5f8c0d703f91993"
+  },
+  {
+   "filename": "state_cancer_profiles_mortality.parquet",
+   "sha256": "d144011cb2569e73dcad7511d63f328022acd8c9df1ad98030a60b923cd80e60",
+   "bytes": 38275580,
+   "format": "parquet",
+   "rows": 5866632
+  },
+  {
+   "filename": "state_cancer_profiles_risk.csv.gz",
+   "sha256": "6a38db5fb8b64e198ef0064c023a36643ffbfd0a090a5f694e1013583c1f8ba6",
+   "bytes": 1407034,
+   "format": "csv.gz",
+   "topic": "risk",
+   "rows": 78798,
+   "content_sha256": "6a370ab842e9d52d2191c11ad7e79331cfcdcf511bda29a9570b78d80095574b"
+  },
+  {
+   "filename": "state_cancer_profiles_risk.parquet",
+   "sha256": "794f6b891faf87dd64c7494b783d5445a6bd455cdd55defecc71e5d8b9ffb9da",
+   "bytes": 644522,
+   "format": "parquet",
+   "rows": 78798
+  }
+ ],
+ "content_hashes": {
+  "demographics": "5b37483e2c2a8328d5f7e31a63898ba04bec1c691a2a4ab9de5591f71aa7d2bc",
+  "incidence": "a120cd6e0f73279460dd4d82dc5152b3afd6e3386cd9c4b194fb50ab9efdee34",
+  "mortality": "16f9f39707390bbb5103ec646a127029e8c93a3e1dc8cdaff5f8c0d703f91993",
+  "risk": "6a370ab842e9d52d2191c11ad7e79331cfcdcf511bda29a9570b78d80095574b"
+ }
+}

--- a/scps/manifest.py
+++ b/scps/manifest.py
@@ -135,3 +135,84 @@ def assign_vintage(manifest: dict, vintages: dict) -> tuple[str, bool]:
             return vid, False
     latest = max(vintages["vintages"], key=lambda v: int(v.lstrip("V")))
     return f"V{int(latest.lstrip('V')) + 1}", True
+
+
+# ---------------------------------------------------------------------------
+# 00_README.txt — NLM-style deposit documentation (generated, never hand-kept)
+# ---------------------------------------------------------------------------
+
+_FILE_BLURBS = (
+    ("state_cancer_profiles_incidence", "Cancer incidence: age-adjusted rates per 100,000 with 95% CIs, trend statistics, and average annual counts, one row per statistical stratum (cancer site x race/ethnicity x sex x age x stage) x locale (county/state/US). From the first 2026-08-24 release onward, upstream-suppressed cells are retained as empty rate fields with an explicit suppression_reason column (suppressed_small_count = fewer than 16 cases; withheld_state_law = Kansas counties); in earlier releases suppressed rows are absent entirely. Source: SEER/NPCR registries via statecancerprofiles.cancer.gov."),
+    ("state_cancer_profiles_mortality", "Cancer mortality: same layout as incidence, without the stage dimension (not applicable to death rates; releases before 2026-08-24 carry a spurious stage column that duplicates every row — see the repository's docs). Source: NCHS vital statistics via statecancerprofiles.cancer.gov."),
+    ("state_cancer_profiles_risk", "Screening and risk-factor prevalence (e.g. smoking, binge drinking, mammography). These are MODEL-BASED small-area estimates built from BRFSS survey data, not registry observations, and refresh on their own cadence independent of the incidence/mortality vintage."),
+    ("state_cancer_profiles_demographics", "Demographic and social-determinant indicators (poverty, education, insurance, SVI, population) from the American Community Survey and related sources, by county/state."),
+    ("notes_", "Verbatim title and footnote blocks from the upstream CSV export for this topic: data windows, source registries, submission year, and suppression-rule definitions as stated by NCI at scrape time."),
+    ("scrape_catalog.jsonl", "One JSON line per query combination known to return data; the exact request inventory this release was scraped from (provenance for every row's originating query)."),
+    ("select_options.json", "The query vocabulary (cancer sites, race/ethnicity, ages, stages...) as served by the website's own form controls at scrape time."),
+    ("gh_hash.txt", "Git commit of the scraper code that produced this release, in the repository below."),
+    ("manifest.json", "Machine-readable inventory: sha256, byte size, row count, and content hash per file, plus provenance fields extracted from the notes."),
+    ("release_note.txt", "Short human note attached to the GitHub release."),
+    ("00_README.txt", "This file."),
+)
+
+
+def _blurb(filename: str) -> str:
+    for prefix, text in _FILE_BLURBS:
+        if filename.startswith(prefix):
+            return text
+    return ""
+
+
+def render_readme(manifest: dict, vintage_id: str, vintages: dict) -> str:
+    """NLM-style plain-text documentation of one deposit's files and provenance."""
+    info = vintages["vintages"][vintage_id]
+    tags = ", ".join(info["releases"])
+    doi = info.get("doi", "(this version)")
+    concept = vintages.get("concept_doi", "10.5281/zenodo.11098814")
+    lines = [
+        "00_README.txt",
+        f"United States State Cancer Profiles data extract - vintage {vintage_id}",
+        "=" * 72,
+        "",
+        "WHAT THIS IS",
+        "",
+        "A complete national county- and state-level extract of the NCI/CDC State",
+        "Cancer Profiles website (statecancerprofiles.cancer.gov), which offers no",
+        "API, bulk download, or archive of prior estimates. A VINTAGE is one",
+        "edition of the upstream estimates: the complete set of values the site",
+        "served during some period, bounded by NCI silently replacing them with",
+        "revised values. Several dated scrapes that captured identical values",
+        "belong to one vintage; this deposit preserves one such edition.",
+        "",
+        "PROVENANCE",
+        "",
+        f"  Vintage:            {vintage_id} (first captured {info['first_capture']})",
+        f"  Deposited bytes:    GitHub release {info['best_capture']} (the vintage's most complete capture)",
+        f"  All capturing tags: {tags}",
+        f"  Version DOI:        {doi}",
+        f"  Concept DOI:        {concept} (always resolves to the latest vintage)",
+        "  Scraper:            https://github.com/seandavi/state-cancer-profile-scraper",
+        "                      (commit in gh_hash.txt; methods in docs/releases.md)",
+        "  License:            CC-BY-4.0",
+        "",
+        "FILES",
+        "",
+    ]
+    for f in manifest["files"]:
+        size = f"{f['bytes']:,} bytes"
+        rows = f" | {f['rows']:,} rows" if "rows" in f else ""
+        lines.append(f"  {f['filename']}  ({size}{rows})")
+        lines.append(f"    sha256: {f['sha256']}")
+        blurb = _blurb(f["filename"])
+        if blurb:
+            import textwrap
+            lines.extend(textwrap.wrap(blurb, width=70, initial_indent="    ", subsequent_indent="    "))
+        lines.append("")
+    lines += [
+        "CITATION",
+        "",
+        f"  Davis S. United States State Cancer Profiles data extract - vintage {vintage_id}.",
+        f"  Zenodo. https://doi.org/{doi}" if doi != "(this version)" else "  Zenodo. (DOI of this version)",
+        "",
+    ]
+    return "\n".join(lines) + "\n"

--- a/scps/zenodo.py
+++ b/scps/zenodo.py
@@ -163,7 +163,17 @@ class VintageDeposit:
     files: list[Path]
 
 
-def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-profile-scraper") -> dict:
+def _inventory_notes(manifest: dict) -> str:
+    """Plain-text file inventory for the record's Additional-notes field —
+    published versions cannot gain files, so the forensics live in metadata."""
+    lines = ["Files in this deposit (sha256 | size | rows):"]
+    for f in manifest["files"]:
+        rows = f" | {f['rows']:,} rows" if "rows" in f else ""
+        lines.append(f"{f['filename']}: {f['sha256']} | {f['bytes']:,} bytes{rows}")
+    return "\n".join(lines)
+
+
+def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-profile-scraper", manifest: dict | None = None) -> dict:
     """Deposit metadata for one vintage version.
 
     ``related_identifiers`` carries every GitHub tag that captured the
@@ -196,7 +206,7 @@ def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-pro
         f"https://github.com/{repo}/blob/main/docs/releases.md</p>"
         + _topics_paragraph(dep)
     )
-    return {
+    md = {
         "title": f"United States State Cancer Profiles data extract — vintage {dep.vintage_id}",
         "upload_type": "dataset",
         "publication_date": dep.publication_date,
@@ -209,6 +219,9 @@ def vintage_metadata(dep: VintageDeposit, repo: str = "seandavi/state-cancer-pro
             for u in tag_urls
         ],
     }
+    if manifest:
+        md["notes"] = _inventory_notes(manifest)
+    return md
 
 
 def _topics_paragraph(dep: VintageDeposit) -> str:
@@ -275,7 +288,7 @@ def plan_backfill(
     return plan
 
 
-def run_deposit(client: ZenodoClient, base_record_id: str, dep: VintageDeposit, dry_run: bool = False) -> str | None:
+def run_deposit(client: ZenodoClient, base_record_id: str, dep: VintageDeposit, dry_run: bool = False, manifest: dict | None = None) -> str | None:
     """Execute one vintage deposit as a new version of ``base_record_id``.
     Returns the new record id (or None on dry run)."""
     logger.info(
@@ -300,7 +313,7 @@ def run_deposit(client: ZenodoClient, base_record_id: str, dep: VintageDeposit, 
     for path in dep.files:
         logger.info("  upload %s (%d bytes)", path.name, path.stat().st_size)
         client.upload_file(draft, path)
-    client.set_metadata(draft, vintage_metadata(dep))
+    client.set_metadata(draft, vintage_metadata(dep, manifest=manifest))
     published = client.publish(draft)
     logger.info("  published %s -> %s", dep.vintage_id, published.get("doi"))
     return str(published.get("id"))

--- a/scripts/zenodo/publish_release.py
+++ b/scripts/zenodo/publish_release.py
@@ -67,6 +67,17 @@ def main() -> int:
                 hashes.append(h)
     else:
         vid, is_new = manifest_mod.assign_vintage(m, vintages)
+
+    # NLM-style deposit documentation; regenerated every release.
+    readme_vintages = dict(vintages)
+    if is_new:
+        readme_vintages = {**vintages, "vintages": {**vintages["vintages"], vid: {
+            "releases": [args.tag], "first_capture": args.tag, "best_capture": args.tag,
+        }}}
+    (args.release_dir / "00_README.txt").write_text(
+        manifest_mod.render_readme(m, vid, readme_vintages)
+    )
+
     if not is_new:
         # Record the tag under its vintage so the mapping stays complete.
         info = vintages["vintages"][vid]
@@ -94,7 +105,7 @@ def main() -> int:
         publication_date=args.tag,
         best_capture=args.tag,
         files=manifest_mod.release_files(args.release_dir)
-        + [args.release_dir / "manifest.json"],
+        + [args.release_dir / "manifest.json", args.release_dir / "00_README.txt"],
     )
 
     if args.sandbox:
@@ -112,7 +123,7 @@ def main() -> int:
             logging.info("Tag already in a deposited version — idempotent no-op.")
             return 0
         latest = versions[-1]["id"] if versions else base_record
-        zenodo.run_deposit(client, str(latest), dep, dry_run=False)
+        zenodo.run_deposit(client, str(latest), dep, dry_run=False, manifest=m)
     else:
         zenodo.run_deposit(zenodo.ZenodoClient(zenodo.SANDBOX, "dry"), "0", dep, dry_run=True)
         # Dry runs record nothing: a vintages.json entry without a deposit

--- a/scripts/zenodo/refresh_metadata.py
+++ b/scripts/zenodo/refresh_metadata.py
@@ -46,7 +46,9 @@ def main() -> int:
         if vid not in deposits:
             logging.info("skip %s (%s) — not a vintage version", version["doi"], title[:50])
             continue
-        md = zenodo.vintage_metadata(deposits[vid])
+        manifest_path = Path("manifests") / f"{deposits[vid].best_capture}.json"
+        manifest = json.loads(manifest_path.read_text()) if manifest_path.exists() else None
+        md = zenodo.vintage_metadata(deposits[vid], manifest=manifest)
         logging.info("refresh %s (%s)%s", version["doi"], vid, " [dry-run]" if args.dry_run else "")
         if args.dry_run:
             continue

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -122,3 +122,20 @@ def test_parquet_row_count_uses_metadata(tmp_path):
     m = manifest.build_manifest(rel, "t")
     pq_entry = next(f for f in m["files"] if f["filename"].endswith(".parquet"))
     assert pq_entry["rows"] == 3
+
+
+def test_render_readme_documents_every_file(tmp_path):
+    rel = _write_release(tmp_path, "2026-01-01T00:00:00")
+    m = manifest.build_manifest(rel, "2026-01-01")
+    vintages = {
+        "concept_doi": "10.5281/zenodo.11098814",
+        "vintages": {"V9": {"releases": ["2026-01-01"], "first_capture": "2026-01-01",
+                            "best_capture": "2026-01-01", "doi": "10.5281/zenodo.999"}},
+    }
+    txt = manifest.render_readme(m, "V9", vintages)
+    for f in m["files"]:
+        assert f["filename"] in txt
+        assert f["sha256"] in txt
+    assert "VINTAGE is one" in txt or "A VINTAGE is one" in txt
+    assert "10.5281/zenodo.999" in txt
+    assert "CC-BY-4.0" in txt

--- a/tests/test_zenodo.py
+++ b/tests/test_zenodo.py
@@ -93,3 +93,17 @@ def test_run_deposit_dry_run_touches_nothing():
     )
     client = zenodo.ZenodoClient("https://example.invalid", "no-token")
     assert zenodo.run_deposit(client, "0", dep, dry_run=True) is None
+
+
+def test_vintage_metadata_notes_inventory(tmp_path):
+    dep = zenodo.VintageDeposit(
+        vintage_id="V1", tags=["t"], publication_date="2024-08-02",
+        best_capture="t", files=[],
+    )
+    manifest = {"files": [
+        {"filename": "a.csv.gz", "sha256": "ab" * 32, "bytes": 1234, "rows": 10},
+        {"filename": "gh_hash.txt", "sha256": "cd" * 32, "bytes": 41},
+    ]}
+    md = zenodo.vintage_metadata(dep, manifest=manifest)
+    assert "a.csv.gz" in md["notes"] and "ab" * 32 in md["notes"] and "10 rows" in md["notes"]
+    assert "notes" not in zenodo.vintage_metadata(dep)


### PR DESCRIPTION
Sean's ask: Zenodo records are otherwise a little forensics. `render_readme` builds a plain-text README from the manifest (what/vintage definition/provenance/per-file inventory with sha256 and content blurbs/citation) — generated, never hand-maintained. Ships with every future release and deposit. For the three already-published versions (files immutable), the same inventory lands in the Additional-notes metadata field on the next `refresh_metadata.py` run. The 2026-08-24 GitHub release gets its README uploaded directly. 92 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)