### PR TITLE
Record medRxiv submission in the editorial state

### DIFF
--- a/manuscript/MANUSCRIPT_STATE.yaml
+++ b/manuscript/MANUSCRIPT_STATE.yaml
@@ -12,7 +12,7 @@ project:
   source_format: quarto
 
 document_phase:
-  current: draft
+  current: submitted  # medRxiv, 2026-08-24; Scientific Data revision pending
 
 core_claims:
   - >-


### PR DESCRIPTION
One-line bookkeeping: MANUSCRIPT_STATE document_phase -> submitted (medRxiv, 2026-08-24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JXY3QYdiAGZ12BpD8pRmg