### PR TITLE
Fix citation issues found in manuscript reference audit

### DIFF
--- a/manuscript/descriptor.qmd
+++ b/manuscript/descriptor.qmd
@@ -166,7 +166,9 @@ and where the choice of vintage is known to change analytic conclusions
 [@croushore2001realtime; @croushore2003vintage]. Cancer surveillance exhibits
 the same phenomenon: reporting delay and reporting error revise incidence
 rates for years after first publication, by enough to change the direction of
-fitted trends [@clegg2002reportingdelay; @das2008completeness]. At each
+fitted trends [@clegg2002reportingdelay], a consequence of the same
+case-ascertainment lag that completeness-of-ascertainment methods are built
+to quantify [@das2008completeness]. At each
 vintage boundary observed in this archive, approximately
 `{python} f"{pct_revised:.0%}"` of previously published estimate
 values changed (Technical Validation).
@@ -191,8 +193,9 @@ values without any indication of change. An earlier R client was abandoned in
 2017 [@silentspring_rscp], and a public repository contains an unpublished
 national SCP sweep feeding a dashboard pipeline, with no release, no registry
 entry, and no DOI [@ciodata_ciftools]. The demand for bulk access is
-nonetheless visible in the workarounds: at least three CRAN packages ship
-hand-frozen, single-window SCP slices as example data
+nonetheless visible in the workarounds: at least three CRAN packages have
+shipped hand-frozen, single-window SCP slices as example data (one,
+`SeerMapper`, was archived from CRAN in 2023)
 [@sarkar_latticeextra; @pearson_seermapper; @otto_spgarch], and the one
 SCP-derived deposit we located in a generalist data repository is a
 single-site, single-window analysis slice [@acharjee2020airquality].
@@ -331,13 +334,17 @@ that constitute the extract's provenance.
 SCP withholds a cell for two documented reasons: counts below 16 in an
 area-sex-race category ("data has been suppressed to ensure confidentiality
 and stability of rate estimates"), and state legislation prohibiting release
-of county-level data. Suppression of this kind is standard practice in
-federal health statistics [@klein2002suppression; @parker2017proportions;
-@talih2023ratesstandards], and NCI's own surveillance program identifies
-county-level suppression as a material limitation of county cancer
-reporting [@tatalovich2022zonedesign]. Adjacent work on census differential
-privacy likewise shows that upstream disclosure-limitation choices propagate
-unevenly into small-area health estimates
+of county-level data. Suppression of small-area cells follows a documented
+federal tradition of protecting rate reliability in health statistics
+[@klein2002suppression], one shared by the reliability and presentation
+standards NCHS applies to its own small-area estimates
+[@parker2017proportions; @talih2023ratesstandards], and NCI's own
+surveillance program identifies county-level suppression as a material
+limitation of county cancer reporting [@tatalovich2022zonedesign]. Adjacent
+work on census differential privacy shows that upstream disclosure-limitation
+choices can affect small-area health estimates unevenly across population
+subgroups, though reported effect sizes vary by geography and outcome, from
+disproportionate in some analyses to negligible in others
 [@santoslozada2020dp; @krieger2021dp; @li2023dpmapping]. In SCP's export the
 two cases appear as an asterisk or a footnote marker inside otherwise
 numeric columns. The scraper decodes them before numeric coercion: the row

--- a/manuscript/refs.bib
+++ b/manuscript/refs.bib
@@ -146,30 +146,6 @@
   note    = {PMID: 37595037}
 }
 
-@article{kurz2022dpmedicaid,
-  author  = {Kurz, Christoph F. and K{\"o}nig, Adriana N. and Emmert-Fees, Karl M. F. and Allen, Lindsay D.},
-  title   = {The effect of differential privacy on {Medicaid} participation among racial and ethnic minority groups},
-  journal = {Health Services Research},
-  year    = {2022},
-  volume  = {57},
-  number  = {S2},
-  pages   = {207--213},
-  doi     = {10.1111/1475-6773.14000},
-  note    = {PMID: 35524543}
-}
-
-@article{rushton2006geocoding,
-  author  = {Rushton, Gerard and Armstrong, Marc P. and Gittler, Josephine and Greene, Barry R. and Pavlik, Claire E. and West, Michele M. and Zimmerman, Dale L.},
-  title   = {Geocoding in cancer research: a review},
-  journal = {American Journal of Preventive Medicine},
-  year    = {2006},
-  volume  = {30},
-  number  = {2, Suppl.},
-  pages   = {S16--S24},
-  doi     = {10.1016/j.amepre.2005.09.011},
-  note    = {PMID: 16458786}
-}
-
 
 % =====================================================================
 % STRAND 2a — Data vintage and estimate revision in official statistics
@@ -567,7 +543,9 @@
   year   = {2021},
   url    = {https://CRAN.R-project.org/package=SeerMapper},
   note   = {R package version 1.2.5. Ships all-site mortality 2009--2013 for GA, WA, KY
-            and CA counties, hand-exported from State Cancer Profiles on 2 September 2016}
+            and CA counties, hand-exported from State Cancer Profiles on 2 September 2016.
+            Archived from CRAN 2023-10-16 (maptools/rgdal deprecation); no longer installable
+            from CRAN, verified via the CRAN package page 2026-08-25}
 }
 
 @manual{otto_spgarch,


### PR DESCRIPTION
## Summary
- Remove two orphaned `refs.bib` entries (`kurz2022dpmedicaid`, `rushton2006geocoding`) never cited in `descriptor.qmd`
- Rework the differential-privacy sentence: `krieger2021dp` found negligible effect and `li2023dpmapping` mixed effects, so the "propagates unevenly" claim overstated two of its three citations
- Decouple `parker2017proportions`/`talih2023ratesstandards` (NCHS reliability/presentation standards) from the suppression claim they were loosely grouped under with `klein2002suppression`
- Decouple `das2008completeness` (a completeness-of-ascertainment methodology paper) from the trend-direction claim it was only indirectly supporting
- Note that `SeerMapper` (`pearson_seermapper`) was archived from CRAN in 2023; the qmd's present-tense "ship... as example data" was stale for that entry

Found via a full hand-verification pass over every citation in `descriptor.qmd`/`refs.bib` (DOI/PMID resolution against PubMed/Crossref, plus context-fit check against the claim each citation is attached to). No fabricated, broken, or hallucinated citations were found — these are wording/scoping fixes, not corrections of false citations.

## Test plan
- [x] Cross-checked citation keys: every `@key` in the qmd resolves to a bib entry, no orphans remain
- [ ] Render the Quarto document to confirm it still builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)